### PR TITLE
Fixes bug with logged in user fetched from $_SESSION (task #2667)

### DIFF
--- a/src/Template/Element/menu.ctp
+++ b/src/Template/Element/menu.ctp
@@ -68,8 +68,10 @@ $itemDefaults = [
 ];
 
 $capsTable = TableRegistry::get('RolesCapabilities.Capabilities');
-$user = [];
-if (isset($_SESSION['Auth']['User'])) {
+
+$user = isset($user) ? $user : [];
+
+if (empty($user) && isset($_SESSION['Auth']['User'])) {
     $user = $_SESSION['Auth']['User'];
 };
 


### PR DESCRIPTION
$_SESSION global variable is not always set (for example in API requests) which causes PHP errors. With this fix the user info can be passed to the element from the caller and if not then it will try to fetch it from the global variable, if it is set.