### PR TITLE
Bug-fix for missing menus (task #2786)

### DIFF
--- a/src/View/Helper/MenuHelper.php
+++ b/src/View/Helper/MenuHelper.php
@@ -27,9 +27,11 @@ class MenuHelper extends Helper
         // get all controllers
         $controllers = $this->_getAllControllers();
         foreach ($controllers as $controller) {
-            if (is_callable([$controller, 'getMenu'])) {
-                $menu = array_merge($menu, $controller::getMenu($name));
+            if (!is_callable([$controller, 'getMenu'])) {
+                continue;
             }
+
+            $menu = array_merge($menu, $controller::getMenu($name));
 
             if (!$allControllers) {
                 break;


### PR DESCRIPTION
Don't break out of the loop on the first run, break only after a Controller's getMenu method has been called.