### PR TITLE
(task #2927) Fixing user drawing of profile menu

### DIFF
--- a/src/Template/Element/menu.ctp
+++ b/src/Template/Element/menu.ctp
@@ -68,7 +68,7 @@ $itemDefaults = [
 
 $user = isset($user) ? $user : [];
 
-if (empty($user) && isset($_SESSION['Auth']['User'])) {
+if (empty($user) || isset($_SESSION['Auth']['User'])) {
     $user = $_SESSION['Auth']['User'];
 };
 


### PR DESCRIPTION
In combination with CakeDC/users plugin, $user variable becomes ORM\Entity, that is not what event `Menu.Menu.beforeRender` expects to be 3rd argument (awaits for `array`).

We overwrite `$user` with session variable to let the user view all his links/menus, not breaking `users/profile/<other_user_id>` functionality.