### PR TITLE
Event names enumeration (task #4352)

### DIFF
--- a/src/Event/EventName.php
+++ b/src/Event/EventName.php
@@ -1,0 +1,14 @@
+<?php
+namespace Menu\Event;
+
+use MyCLabs\Enum\Enum;
+
+/**
+ * Event Name enum
+ */
+class EventName extends Enum
+{
+    const GET_MENU_ITEMS = 'Menu.Menu.getMenuItems';
+    const GET_MENU = 'Menu.Menu.getMenu';
+    const MENU_BEFORE_RENDER = 'Menu.Menu.beforeRender';
+}

--- a/src/Template/Cell/Menu/display.ctp
+++ b/src/Template/Cell/Menu/display.ctp
@@ -1,12 +1,12 @@
 <?php
-
 use Cake\Event\Event;
+use Menu\Event\EventName;
 use Menu\MenuBuilder\MainMenuRenderAdminLte;
 use Menu\MenuBuilder\Menu;
 use Menu\MenuBuilder\MenuItemFactory;
 use Menu\MenuBuilder\SystemMenuRenderAdminLte;
 
-$event = new Event('Menu.Menu.beforeRender', $this, ['menu' => $menuItems, 'user' => $user]);
+$event = new Event((string)EventName::MENU_BEFORE_RENDER(), $this, ['menu' => $menuItems, 'user' => $user]);
 $this->eventManager()->dispatch($event);
 if (!empty($event->result)) {
     $menuItems = $event->result;

--- a/src/Template/Element/menu.ctp
+++ b/src/Template/Element/menu.ctp
@@ -1,5 +1,6 @@
 <?php
 use Cake\Event\Event;
+use Menu\Event\EventName;
 
 $name = isset($name) ? $name : 'main';
 
@@ -17,7 +18,7 @@ $renderAs = isset($renderAs) ? $renderAs : RENDER_AS_LIST;
 $menu = isset($menu) ? $menu : [];
 
 if (empty($menu)) {
-    $event = new Event('Menu.Menu.getMenu', $this, [
+    $event = new Event((string)EventName::GET_MENU(), $this, [
         'name' => $name,
         'user' => $user,
         'fullBaseUrl' => isset($fullBaseUrl) ? (bool)$fullBaseUrl : false
@@ -80,7 +81,7 @@ $itemDefaults = [
     'icon' => 'circle-o'
 ];
 
-$event = new Event('Menu.Menu.beforeRender', $this, ['menu' => $menu, 'user' => $user]);
+$event = new Event((string)EventName::MENU_BEFORE_RENDER(), $this, ['menu' => $menu, 'user' => $user]);
 $this->eventManager()->dispatch($event);
 if (!empty($event->result)) {
     $menu = $event->result;

--- a/src/View/Cell/MenuCell.php
+++ b/src/View/Cell/MenuCell.php
@@ -5,6 +5,7 @@ use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
 use Cake\View\Cell;
 use InvalidArgumentException;
+use Menu\Event\EventName;
 
 class MenuCell extends Cell
 {
@@ -136,7 +137,7 @@ class MenuCell extends Cell
      */
     protected function _getMenuItemsFromEvent(EntityInterface $menu, array $modules = [])
     {
-        $event = new Event('Menu.Menu.getMenuItems', $this, [
+        $event = new Event((string)EventName::GET_MENU_ITEMS(), $this, [
             'name' => $menu->name,
             'user' => $this->_user,
             'fullBaseUrl' => $this->_fullBaseUrl,


### PR DESCRIPTION
Use [php-enum](https://github.com/myclabs/php-enum) library to define event names enum. Modified all events to use `EventName` enumeration class.