### PR TITLE
Enable/Disable Menu Items

### DIFF
--- a/src/MenuBuilder/BaseMenuItem.php
+++ b/src/MenuBuilder/BaseMenuItem.php
@@ -86,6 +86,16 @@ abstract class BaseMenuItem implements MenuItemInterface
     protected $children = [];
 
     /**
+     * @var bool
+     */
+    private $enabled = true;
+    /**
+     * @var array List of callbacks to be evaluated as conditions
+     */
+    private $conditions = [];
+
+
+    /**
      *  getLabel method
      *
      * @return string menu item label
@@ -327,5 +337,56 @@ abstract class BaseMenuItem implements MenuItemInterface
         });
 
         return $this->children;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setEnabled($enabled) {
+        $this->enabled = $enabled;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function enable()
+    {
+        $this->setEnabled(true);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function disable()
+    {
+        $this->setEnabled(false);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function disableIf(callable $callback)
+    {
+        $this->conditions[] = $callback;
+    }
+    /**
+     * @inheritdoc
+     */
+    public function isEnabled()
+    {
+        // Enabled flag is set to false
+        if (!$this->enabled) {
+            return false;
+        }
+
+        // Evaluate each one of the defined conditions
+        foreach ($this->conditions as $condition) {
+            $disabled = call_user_func($condition, $this);
+            if ($disabled) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/src/MenuBuilder/BaseMenuRenderClass.php
+++ b/src/MenuBuilder/BaseMenuRenderClass.php
@@ -88,8 +88,13 @@ class BaseMenuRenderClass implements MenuRenderInterface
         $html = $this->format['menuStart'];
         $html .= !empty($options['title']) ? $options['title'] : '';
 
-        foreach ($this->menu->getMenuItems() as $index => $menuItem) {
-            $html .= $this->_renderMenuItem($menuItem);
+        /**
+         * @var MenuItemInterface $menuItem
+         */
+        foreach ($this->menu->getMenuItems() as $menuItem) {
+            if ($menuItem->isEnabled()) {
+                $html .= $this->_renderMenuItem($menuItem);
+            }
         }
         $html .= $this->format['menuEnd'];
 
@@ -112,10 +117,13 @@ class BaseMenuRenderClass implements MenuRenderInterface
 
         if (!empty($children)) {
             $html .= $this->format['childMenuStart'];
+            /** @var MenuItemInterface $childItem */
             foreach ($children as $childItem) {
-                $html .= !empty($this->format['childItemStart']) ? $this->format['childItemStart'] : '';
-                $html .= $this->_renderMenuItem($childItem);
-                $html .= !empty($this->format['childItemEnd']) ? $this->format['childItemEnd'] : '';
+                if ($childItem->isEnabled()) {
+                    $html .= !empty($this->format['childItemStart']) ? $this->format['childItemStart'] : '';
+                    $html .= $this->_renderMenuItem($childItem);
+                    $html .= !empty($this->format['childItemEnd']) ? $this->format['childItemEnd'] : '';
+                }
             }
             $html .= $this->format['childMenuEnd'];
         }

--- a/src/MenuBuilder/BaseMenuRenderClass.php
+++ b/src/MenuBuilder/BaseMenuRenderClass.php
@@ -119,7 +119,8 @@ class BaseMenuRenderClass implements MenuRenderInterface
             }
             $html .= $this->format['childMenuEnd'];
         }
-        $this->format['itemEnd'];
+
+        $html .= $this->format['itemEnd'];
 
         return $html;
     }

--- a/src/MenuBuilder/MenuItemInterface.php
+++ b/src/MenuBuilder/MenuItemInterface.php
@@ -41,4 +41,42 @@ interface MenuItemInterface
      * @return void
      */
     public function removeChild($childId);
+
+    /**
+     * Sets the enabled flag to the provided value
+     * @param boolean $enabled
+     * @return mixed
+     */
+    public function setEnabled($enabled);
+
+    /**
+     * Sets the enabled flag to true.
+     * Alias for setEnabled(true)
+     * @see MenuItemInterface::setEnabled()
+     * @return void
+     */
+    public function enable();
+
+    /**
+     * Sets the enabled flag to false.
+     * Alias for setEnabled(false)
+     * @see MenuItemInterface::setEnabled()
+     * @return  void
+     */
+    public function disable();
+
+    /**
+     * Adds a new condition to determine whether this item must be disabled
+     * @param callable $callback
+     * @return void
+     */
+    public function disableIf(callable $callback);
+
+    /**
+     * Returns true only and only if:
+     * - enabled flag is set to true
+     * - all defined conditions are being evaluated to false
+     * @return boolean
+     */
+    public function isEnabled();
 }

--- a/tests/TestCase/MenuBuilder/BaseMenuRenderClassTest.php
+++ b/tests/TestCase/MenuBuilder/BaseMenuRenderClassTest.php
@@ -5,16 +5,34 @@ use Cake\TestSuite\TestCase;
 use Cake\View\View;
 use Menu\MenuBuilder\BaseMenuRenderClass;
 use Menu\MenuBuilder\Menu;
+use Menu\MenuBuilder\MenuInterface;
 use Menu\MenuBuilder\MenuItemButton;
+use Menu\MenuBuilder\MenuItemLink;
 use Menu\MenuBuilder\MenuItemLinkButton;
 use Menu\MenuBuilder\MenuItemLinkButtonModal;
 use Menu\MenuBuilder\MenuItemLinkModal;
 use Menu\MenuBuilder\MenuItemPostlink;
 use Menu\MenuBuilder\MenuItemPostlinkButton;
 use Menu\MenuBuilder\MenuItemSeparator;
+use Menu\MenuBuilder\MenuRenderInterface;
 
 class BaseMenuRenderClassTest extends TestCase
 {
+    /**
+     * @var View
+     */
+    private $view;
+
+    /**
+     * @var MenuInterface
+     */
+    private $menu;
+
+    /**
+     * @var MenuRenderInterface
+     */
+    private $menuRenderer;
+
     public function setUp()
     {
         parent::setUp();
@@ -27,7 +45,11 @@ class BaseMenuRenderClassTest extends TestCase
             'menuStart' => '<ul>',
             'menuEnd' => '</ul>',
             'itemStart' => '<li>',
-            'itemEnd' => '</li>'
+            'itemEnd' => '</li>',
+            'childMenuStart' => '<ul>',
+            'childMenuEnd' => '</ul>',
+            'childItemStart' => '<lo>',
+            'childItemEnd' => '</lo>',
         ]);
     }
 

--- a/tests/TestCase/MenuBuilder/BaseMenuRenderClassTest.php
+++ b/tests/TestCase/MenuBuilder/BaseMenuRenderClassTest.php
@@ -47,6 +47,36 @@ class BaseMenuRenderClassTest extends TestCase
         $this->assertEquals($expected, $this->menuRenderer->render());
     }
 
+    public function testRenderMenuWithDisabledItem()
+    {
+        $item = new MenuItemLink();
+        $item->setUrl('http://example.com');
+        $item->setLabel('Link');
+        $item->disable();
+        $this->menu->addMenuItem($item);
+
+        $expected = '<ul></ul>';
+        $this->assertEquals($expected, $this->menuRenderer->render());
+    }
+
+    public function testRenderMenuWithNestedDisabledItem()
+    {
+        $item = new MenuItemLink();
+        $item->setUrl('#');
+        $item->setLabel('Link');
+        $this->menu->addMenuItem($item);
+
+        $subitem = new MenuItemLink();
+        $subitem->setUrl('http://example.com');
+        $subitem->setLabel('SubLink');
+        $subitem->disable();
+        $item->addChild($subitem);
+
+        $html = $this->menuRenderer->render();
+        $this->assertStringStartsWith('<ul><li><a', $html);
+        $this->assertStringEndsWith('<ul></ul></li></ul>', $html);
+    }
+
     public function testRenderMenuWithButton()
     {
         $item = new MenuItemButton();
@@ -55,7 +85,7 @@ class BaseMenuRenderClassTest extends TestCase
 
         $this->menu->addMenuItem($item);
 
-        $expected = '<ul><li><button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Button</button></ul>';
+        $expected = '<ul><li><button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Button</button></li></ul>';
 
         $this->assertEquals($expected, $this->menuRenderer->render());
     }
@@ -68,7 +98,7 @@ class BaseMenuRenderClassTest extends TestCase
 
         $this->menu->addMenuItem($item);
 
-        $expected = '<ul><li><a href="http://example.com" class="btn btn-default" title="Link Button" target="_self"><i class="menu-icon fa fa-"></i> Link Button</a></ul>';
+        $expected = '<ul><li><a href="http://example.com" class="btn btn-default" title="Link Button" target="_self"><i class="menu-icon fa fa-"></i> Link Button</a></li></ul>';
 
         $this->assertEquals($expected, $this->menuRenderer->render());
     }
@@ -81,7 +111,7 @@ class BaseMenuRenderClassTest extends TestCase
 
         $this->menu->addMenuItem($item);
 
-        $expected = '<ul><li><a href="#" class="btn btn-default" data-toggle="modal" data-target="#" title="Button Modal" target="_self"><i class="menu-icon fa fa-"></i> Button Modal</a></ul>';
+        $expected = '<ul><li><a href="#" class="btn btn-default" data-toggle="modal" data-target="#" title="Button Modal" target="_self"><i class="menu-icon fa fa-"></i> Button Modal</a></li></ul>';
 
         $this->assertEquals($expected, $this->menuRenderer->render());
     }
@@ -94,7 +124,7 @@ class BaseMenuRenderClassTest extends TestCase
 
         $this->menu->addMenuItem($item);
 
-        $expected = '<ul><li><a href="#" data-toggle="modal" data-target="#" title="Modal" target="_self"><i class="menu-icon fa fa-"></i> Modal</a></ul>';
+        $expected = '<ul><li><a href="#" data-toggle="modal" data-target="#" title="Modal" target="_self"><i class="menu-icon fa fa-"></i> Modal</a></li></ul>';
 
         $this->assertEquals($expected, $this->menuRenderer->render());
     }
@@ -113,7 +143,7 @@ class BaseMenuRenderClassTest extends TestCase
             'type="hidden" name="_method" value="POST"\/><\/form><a href="#" title="Post Link" ' .
             'onclick="document.post_' .
             '\w+' .
-            '.submit\(\); event.returnValue = false; return false;"><i class="fa fa-"><\/i> Post Link<\/a><\/ul>';
+            '.submit\(\); event.returnValue = false; return false;"><i class="fa fa-"><\/i> Post Link<\/a><\/li><\/ul>';
 
         $this->assertRegExp('/' . $pattern . '/', $this->menuRenderer->render());
     }
@@ -132,7 +162,7 @@ class BaseMenuRenderClassTest extends TestCase
             'type="hidden" name="_method" value="POST"\/><\/form><a href="#" class="btn ' .
             'btn-default" title="Postlink Button" onclick="document.post_' .
             '(\w+)' .
-            '.submit\(\); event.returnValue = false; return false;"><i class="fa fa-"><\/i> Postlink Button<\/a><\/ul>';
+            '.submit\(\); event.returnValue = false; return false;"><i class="fa fa-"><\/i> Postlink Button<\/a><\/li><\/ul>';
 
         $this->assertRegExp('/' . $pattern . '/', $this->menuRenderer->render());
     }
@@ -143,7 +173,7 @@ class BaseMenuRenderClassTest extends TestCase
 
         $this->menu->addMenuItem($item);
 
-        $expected = '<ul><li><hr class="separator" /></ul>';
+        $expected = '<ul><li><hr class="separator" /></li></ul>';
 
         $this->assertEquals($expected, $this->menuRenderer->render());
     }

--- a/tests/TestCase/MenuBuilder/MenuItemButtonTest.php
+++ b/tests/TestCase/MenuBuilder/MenuItemButtonTest.php
@@ -2,10 +2,14 @@
 namespace Menu\Test\TestCase\MenuBuilder;
 
 use Cake\TestSuite\TestCase;
+use Menu\MenuBuilder\BaseMenuItem;
 use Menu\MenuBuilder\MenuItemButton;
 
 class MenuItemButtonTest extends TestCase
 {
+    /**
+     * @var BaseMenuItem
+     */
     public $menuItem;
 
     public function setUp()
@@ -185,5 +189,27 @@ class MenuItemButtonTest extends TestCase
         return [
             [$dummy, [$dummy], "Cannot identify an objects array"],
         ];
+    }
+
+    public function testEnabledFlag()
+    {
+        $item = new MenuItemButton();
+        $this->assertTrue($item->isEnabled());
+        $item->disable();
+        $this->assertFalse($item->isEnabled());
+        $item->enable();
+        $this->assertTrue($item->isEnabled());
+    }
+    public function testConditions()
+    {
+        $item = new MenuItemButton();
+        $item->disableIf(function() {
+            return false;
+        });
+        $this->assertTrue($item->isEnabled());
+        $item->disableIf(function() {
+            return true;
+        });
+        $this->assertFalse($item->isEnabled());
     }
 }


### PR DESCRIPTION
* Add `enable`/`disable` methods. By default a menu item is enabled. It's up to the `Renderer` to render or not the disabled items.
* Add `disableIf` method which accepts one or more callbacks. `disableIf` can be used to lazy disable items which are not in allow list or user doesn't have access.
* Add `isEnabled` which returns true only and only the enable flag is true and all callbacks defined by `disabledIf` evaluate to false
* Update renderer to render only the enabled items.