### PR TITLE
Better interfaces (task #809)

### DIFF
--- a/src/MenuBuilder/BaseMenuItem.php
+++ b/src/MenuBuilder/BaseMenuItem.php
@@ -12,10 +12,11 @@
 namespace Menu\MenuBuilder;
 
 use Cake\Network\Exception\NotImplementedException;
-use http\Exception\BadMethodCallException;
 
 abstract class BaseMenuItem implements MenuItemInterface
 {
+    use MenuItemContainerTrait;
+
     /**
      * const DEFAULT_MENU_ITEM_TYPE
      */
@@ -313,7 +314,7 @@ abstract class BaseMenuItem implements MenuItemInterface
      */
     public function addChild(MenuItemInterface $child)
     {
-        array_push($this->children, $child);
+        $this->add($child);
     }
 
     /**
@@ -334,11 +335,7 @@ abstract class BaseMenuItem implements MenuItemInterface
      */
     public function getChildren()
     {
-        usort($this->children, function ($a, $b) {
-            return $a->getOrder() > $b->getOrder();
-        });
-
-        return $this->children;
+        return $this->getAll();
     }
 
     /**
@@ -404,42 +401,5 @@ abstract class BaseMenuItem implements MenuItemInterface
         }
 
         return true;
-    }
-
-    /**
-     * @inheritdoc.
-     *
-     * @param MenuItemInterface $item the menu item to be added
-     * @return void
-     */
-    public function add(MenuItemInterface $item)
-    {
-        $this->addChild($item);
-    }
-
-    /**
-     * @inheritdoc
-     *
-     * @return array List of menu items
-     */
-    public function getAll()
-    {
-        return $this->getChildren();
-    }
-
-    /**
-     * @inheritdoc.
-     *
-     * @param MenuItemInterface $item  The item to be removed from the menu.
-     * @return void
-     */
-    public function remove(MenuItemInterface $item)
-    {
-        $key = array_search($item, $this->children);
-        if ($key === false) {
-            return;
-        }
-
-        $this->removeChild($key);
     }
 }

--- a/src/MenuBuilder/BaseMenuItem.php
+++ b/src/MenuBuilder/BaseMenuItem.php
@@ -305,32 +305,38 @@ abstract class BaseMenuItem implements MenuItemInterface
      *  addChild method
      *
      * @param MenuItemInterface $child menu item
+     * @deprecated Use add method instead.
      * @return void
      */
     public function addChild(MenuItemInterface $child)
     {
-        $this->add($child);
+        trigger_error('Method ' . __METHOD__ . ' is deprecated. Use add method instead', E_USER_DEPRECATED);
+        $this->addMenuItem($child);
     }
 
     /**
      * removeChild method
      *
      * @param string $childId to be removed
+     * @deprecated Use remove method instead.
      * @return void
      */
     public function removeChild($childId)
     {
-        throw new NotImplementedException('Method ' . __METHOD__ . ' is not implemented yet!');
+        trigger_error('Method ' . __METHOD__ . ' is deprecated. Use remove method instead', E_USER_DEPRECATED);
     }
 
     /**
      *  getChildren method
      *
+     * @deprecated Use getAll method instead.
      * @return array list of child items
      */
     public function getChildren()
     {
-        return $this->getAll();
+        trigger_error('Method ' . __METHOD__ . ' is deprecated. Use getAll method instead', E_USER_DEPRECATED);
+
+        return $this->getMenuItems();
     }
 
     /**

--- a/src/MenuBuilder/BaseMenuItem.php
+++ b/src/MenuBuilder/BaseMenuItem.php
@@ -12,6 +12,7 @@
 namespace Menu\MenuBuilder;
 
 use Cake\Network\Exception\NotImplementedException;
+use http\Exception\BadMethodCallException;
 
 abstract class BaseMenuItem implements MenuItemInterface
 {
@@ -156,6 +157,7 @@ abstract class BaseMenuItem implements MenuItemInterface
     {
         $this->target = $target;
     }
+
     /**
      *  getDescription method
      *
@@ -218,6 +220,7 @@ abstract class BaseMenuItem implements MenuItemInterface
     {
         $this->confirmMsg = $message;
     }
+
     /**
      *  getExtraAttribute method
      *
@@ -379,6 +382,7 @@ abstract class BaseMenuItem implements MenuItemInterface
     {
         $this->conditions[] = $callback;
     }
+
     /**
      * @inheritdoc
      *
@@ -400,5 +404,42 @@ abstract class BaseMenuItem implements MenuItemInterface
         }
 
         return true;
+    }
+
+    /**
+     * @inheritdoc.
+     *
+     * @param MenuItemInterface $item the menu item to be added
+     * @return void
+     */
+    public function add(MenuItemInterface $item)
+    {
+        $this->addChild($item);
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @return array List of menu items
+     */
+    public function getAll()
+    {
+        return $this->getChildren();
+    }
+
+    /**
+     * @inheritdoc.
+     *
+     * @param MenuItemInterface $item  The item to be removed from the menu.
+     * @return void
+     */
+    public function remove(MenuItemInterface $item)
+    {
+        $key = array_search($item, $this->children);
+        if ($key === false) {
+            return;
+        }
+
+        $this->removeChild($key);
     }
 }

--- a/src/MenuBuilder/BaseMenuItem.php
+++ b/src/MenuBuilder/BaseMenuItem.php
@@ -11,8 +11,6 @@
  */
 namespace Menu\MenuBuilder;
 
-use Cake\Network\Exception\NotImplementedException;
-
 abstract class BaseMenuItem implements MenuItemInterface
 {
     use MenuItemContainerTrait;

--- a/src/MenuBuilder/BaseMenuItem.php
+++ b/src/MenuBuilder/BaseMenuItem.php
@@ -83,11 +83,6 @@ abstract class BaseMenuItem implements MenuItemInterface
     protected $rawHtml = '';
 
     /**
-     * @var $children
-     */
-    protected $children = [];
-
-    /**
      * @var bool
      */
     private $enabled = true;
@@ -97,9 +92,9 @@ abstract class BaseMenuItem implements MenuItemInterface
     private $conditions = [];
 
     /**
-     *  getLabel method
+     * @inheritdoc
      *
-     * @return string menu item label
+     * @return string the label of this menu item, or null if this menu item has no label.
      */
     public function getLabel()
     {
@@ -107,9 +102,9 @@ abstract class BaseMenuItem implements MenuItemInterface
     }
 
     /**
-     *  setLabel method
+     * @inheritdoc
      *
-     * @param string $label for menu item
+     * @param string $label the new label, or null for no label.
      * @return void
      */
     public function setLabel($label)
@@ -118,9 +113,9 @@ abstract class BaseMenuItem implements MenuItemInterface
     }
 
     /**
-     *  getIcon method
+     * @inheritdoc
      *
-     * @return string menu item icon name
+     * @return string the icon of this menu item, or null if this menu item has no icon.
      */
     public function getIcon()
     {
@@ -128,9 +123,9 @@ abstract class BaseMenuItem implements MenuItemInterface
     }
 
     /**
-     *  setIcon method
+     * @inheritdoc
      *
-     * @param string $icon for menu item
+     * @param string $icon the new icon, or null for no icon.
      * @return void
      */
     public function setIcon($icon)
@@ -139,9 +134,9 @@ abstract class BaseMenuItem implements MenuItemInterface
     }
 
     /**
-     *  getTarget method
+     * @inheritdoc
      *
-     * @return string menu item target
+     * @return string the target of this menu item.
      */
     public function getTarget()
     {
@@ -149,9 +144,9 @@ abstract class BaseMenuItem implements MenuItemInterface
     }
 
     /**
-     *  setTarget method
+     * @inheritdoc
      *
-     * @param string $target for menu item
+     * @param string $target the new target.
      * @return void
      */
     public function setTarget($target)
@@ -160,9 +155,9 @@ abstract class BaseMenuItem implements MenuItemInterface
     }
 
     /**
-     *  getDescription method
+     * @inheritdoc
      *
-     * @return string menu item description
+     * @return string the description of this menu item, or null if this menu item has no description.
      */
     public function getDescription()
     {
@@ -170,9 +165,9 @@ abstract class BaseMenuItem implements MenuItemInterface
     }
 
     /**
-     *  setDescription method
+     * @inheritdoc
      *
-     * @param string $descr for menu item
+     * @param string $descr the new description, or null for no description.
      * @return void
      */
     public function setDescription($descr)
@@ -181,9 +176,9 @@ abstract class BaseMenuItem implements MenuItemInterface
     }
 
     /**
-     *  getUrl method
+     * @inheritdoc
      *
-     * @return array or string menu item URL
+     * @return string|array the URL of this menu item, or null if this menu item has no URL.
      */
     public function getUrl()
     {
@@ -191,9 +186,9 @@ abstract class BaseMenuItem implements MenuItemInterface
     }
 
     /**
-     *  setUrl method
+     * @inheritdoc
      *
-     * @param string or array $url for menu item
+     * @param string|array $url the new URL, or null for no URL.
      * @return void
      */
     public function setUrl($url)
@@ -233,9 +228,9 @@ abstract class BaseMenuItem implements MenuItemInterface
     }
 
     /**
-     * getRawHtml method
+     * @inheritdoc
      *
-     * @return string raw html
+     * @return string the raw HTML for this menu item, or null if no HTML was provided.
      */
     public function getRawHtml()
     {
@@ -243,9 +238,9 @@ abstract class BaseMenuItem implements MenuItemInterface
     }
 
     /**
-     * setRawHtml method
+     * @inheritdoc
      *
-     * @param string $rawHtml for menu item, i.e. modal window or so
+     * @param string $rawHtml the new HTML, or null for no HTML.
      * @return void
      */
     public function setRawHtml($rawHtml)
@@ -265,9 +260,9 @@ abstract class BaseMenuItem implements MenuItemInterface
     }
 
     /**
-     * getOrder method
+     * @inheritdoc
      *
-     * @return int menu item order
+     * @return int the position of this menu item.
      */
     public function getOrder()
     {
@@ -275,9 +270,9 @@ abstract class BaseMenuItem implements MenuItemInterface
     }
 
     /**
-     * setOrder method
+     * @inheritdoc
      *
-     * @param int $order for menu item
+     * @param int $order the new position.
      * @return void
      */
     public function setOrder($order)

--- a/src/MenuBuilder/BaseMenuItem.php
+++ b/src/MenuBuilder/BaseMenuItem.php
@@ -303,12 +303,12 @@ abstract class BaseMenuItem implements MenuItemInterface
      *  addChild method
      *
      * @param MenuItemInterface $child menu item
-     * @deprecated Use add method instead.
+     * @deprecated Use addMenuItem method instead.
      * @return void
      */
     public function addChild(MenuItemInterface $child)
     {
-        trigger_error('Method ' . __METHOD__ . ' is deprecated. Use add method instead', E_USER_DEPRECATED);
+        trigger_error('Method ' . __METHOD__ . ' is deprecated. Use addMenuItem method instead', E_USER_DEPRECATED);
         $this->addMenuItem($child);
     }
 
@@ -316,23 +316,23 @@ abstract class BaseMenuItem implements MenuItemInterface
      * removeChild method
      *
      * @param string $childId to be removed
-     * @deprecated Use remove method instead.
+     * @deprecated Use removeMenuItem method instead.
      * @return void
      */
     public function removeChild($childId)
     {
-        trigger_error('Method ' . __METHOD__ . ' is deprecated. Use remove method instead', E_USER_DEPRECATED);
+        trigger_error('Method ' . __METHOD__ . ' is deprecated. Use removeMenuItem method instead', E_USER_DEPRECATED);
     }
 
     /**
      *  getChildren method
      *
-     * @deprecated Use getAll method instead.
+     * @deprecated Use getMenuItems method instead.
      * @return array list of child items
      */
     public function getChildren()
     {
-        trigger_error('Method ' . __METHOD__ . ' is deprecated. Use getAll method instead', E_USER_DEPRECATED);
+        trigger_error('Method ' . __METHOD__ . ' is deprecated. Use getMenuItems method instead', E_USER_DEPRECATED);
 
         return $this->getMenuItems();
     }

--- a/src/MenuBuilder/BaseMenuRenderClass.php
+++ b/src/MenuBuilder/BaseMenuRenderClass.php
@@ -11,8 +11,7 @@
  */
 namespace Menu\MenuBuilder;
 
-use Cake\View\Helper\UrlHelper;
-use Menu\MenuBuilder\Menu;
+use Cake\View\View;
 
 /**
  *  BaseMenuRenderClass class
@@ -29,12 +28,12 @@ class BaseMenuRenderClass implements MenuRenderInterface
     protected $format = [];
 
     /**
-     * @var $menu list of menu items
+     * @var Menu $menu
      */
     protected $menu = null;
 
     /**
-     * @var $viewEntity
+     * @var View $viewEntity
      */
     protected $viewEntity = null;
 
@@ -50,7 +49,7 @@ class BaseMenuRenderClass implements MenuRenderInterface
      * @param \Cake\View\View $viewEntity view entity
      * @return void
      */
-    public function __construct($menu, $viewEntity)
+    public function __construct(Menu $menu, View $viewEntity)
     {
         $this->menu = $menu;
         $this->viewEntity = $viewEntity;
@@ -107,16 +106,16 @@ class BaseMenuRenderClass implements MenuRenderInterface
      * @param \Menu\MenuBuilder\MenuItemInterface $item menu item definition
      * @return string rendered menu item as HTML
      */
-    protected function renderMenuItem($item)
+    protected function renderMenuItem(MenuItemInterface $item)
     {
-        $children = $item->getChildren();
+        $children = $item->getMenuItems();
 
         $html = $this->format['itemStart'];
 
         $html .= $this->_buildItem($item, !empty($children) && !empty($this->format['itemWithChildrenPostfix']) ? $this->format['itemWithChildrenPostfix'] : '');
 
         if (!empty($children)) {
-            $enabledChildren = array_filter($children, function ($child) {
+            $enabledChildren = array_filter($children, function (MenuItemInterface $child) {
                 return $child->isEnabled();
             });
 
@@ -138,11 +137,11 @@ class BaseMenuRenderClass implements MenuRenderInterface
     /**
      *  _buildItem method
      *
-     * @param \Menu\MenuBuilder\Menu $item menu item entity
+     * @param MenuItemInterface $item menu item entity
      * @param string $extLabel additional label elements
      * @return string generated HTML element
      */
-    protected function _buildItem($item, $extLabel)
+    protected function _buildItem(MenuItemInterface $item, $extLabel)
     {
         $class = get_class($item);
         // Menu\MenuBuilder\MenuItemLink
@@ -180,12 +179,12 @@ class BaseMenuRenderClass implements MenuRenderInterface
     /**
      *  _buildLink method
      *
-     * @param \Menu\MenuBuilder\Menu $item menu item entity
+     * @param MenuItemInterface $item menu item entity
      * @param string $extLabel additional label elements
      * @param array $params additional params
      * @return string generated HTML element
      */
-    protected function _buildLink($item, $extLabel = '', $params = [])
+    protected function _buildLink(MenuItemInterface $item, $extLabel = '', $params = [])
     {
         $params['title'] = __($item->getLabel());
         $params['escape'] = false;
@@ -207,11 +206,11 @@ class BaseMenuRenderClass implements MenuRenderInterface
     /**
      *  _buildLinkButton method
      *
-     * @param \Menu\MenuBuilder\Menu $item menu item entity
+     * @param MenuItemLinkButton $item menu item entity
      * @param string $extLabel additional label elements
      * @return string generated HTML element
      */
-    protected function _buildLinkButton($item, $extLabel)
+    protected function _buildLinkButton(MenuItemLinkButton $item, $extLabel)
     {
         $params = ['class' => 'btn btn-default'];
 
@@ -229,12 +228,12 @@ class BaseMenuRenderClass implements MenuRenderInterface
     /**
      * _buildLinkButtonModal method
      *
-     * @param \Menu\MenuBuilder\Menu $item menu item entity
+     * @param MenuItemLinkModal $item menu item entity
      * @param string $extLabel additional label elements
      * @param array $params additional params
      * @return string generated HTML element
      */
-    protected function _buildLinkModal($item, $extLabel, $params = [])
+    protected function _buildLinkModal(MenuItemLinkModal $item, $extLabel, $params = [])
     {
         $item->setUrl('#');
 
@@ -247,11 +246,11 @@ class BaseMenuRenderClass implements MenuRenderInterface
     /**
      * _buildLinkButtonModal method
      *
-     * @param \Menu\MenuBuilder\Menu $item menu item entity
+     * @param MenuItemLinkButtonModal $item menu item entity
      * @param string $extLabel additional label elements
      * @return string generated HTML element
      */
-    protected function _buildLinkButtonModal($item, $extLabel)
+    protected function _buildLinkButtonModal(MenuItemLinkButtonModal $item, $extLabel)
     {
         $item->setUrl('#');
 
@@ -265,12 +264,12 @@ class BaseMenuRenderClass implements MenuRenderInterface
     /**
      *  _buildPostlink method
      *
-     * @param \Menu\MenuBuilder\Menu $item menu item entity
+     * @param MenuItemPostlink $item menu item entity
      * @param string $postFix additional label elements
      * @param array $params additional params
      * @return string generated HTML element
      */
-    protected function _buildPostlink($item, $postFix, $params = [])
+    protected function _buildPostlink(MenuItemPostlink $item, $postFix, $params = [])
     {
         $params['title'] = $item->getLabel();
         $params['escape'] = false;
@@ -288,11 +287,11 @@ class BaseMenuRenderClass implements MenuRenderInterface
     /**
      *  _buildPostlinkButton method
      *
-     * @param \Menu\MenuBuilder\Menu $item menu item entity
+     * @param MenuItemPostlinkButton $item menu item entity
      * @param string $postFix additional label elements
      * @return string generated HTML element
      */
-    protected function _buildPostlinkButton($item, $postFix)
+    protected function _buildPostlinkButton(MenuItemPostlinkButton $item, $postFix)
     {
         $params['class'] = 'btn btn-default';
 
@@ -302,11 +301,11 @@ class BaseMenuRenderClass implements MenuRenderInterface
     /**
      *  _buildButton method
      *
-     * @param \Menu\MenuBuilder\Menu $item menu item entity
+     * @param MenuItemButton $item menu item entity
      * @param string $postFix additional label elements
      * @return string generated HTML element
      */
-    protected function _buildButton($item, $postFix)
+    protected function _buildButton(MenuItemButton $item, $postFix)
     {
         $params = [
             'type' => 'button',
@@ -316,7 +315,7 @@ class BaseMenuRenderClass implements MenuRenderInterface
             $params['class'] = $item->getExtraAttribute();
         }
 
-        if (!empty($item->getChildren())) {
+        if (!empty($item->getMenuItems())) {
             $params['data-toggle'] = 'dropdown';
             $params['aria-haspopup'] = 'true';
             $params['aria-expanded'] = 'false';
@@ -339,11 +338,11 @@ class BaseMenuRenderClass implements MenuRenderInterface
     /**
      *  _buildSeparator method
      *
-     * @param \Menu\MenuBuilder\Menu $item menu item entity
+     * @param MenuItemSeparator $item menu item entity
      * @param string $postFix additional label elements
      * @return string generated HTML element
      */
-    protected function _buildSeparator($item, $postFix)
+    protected function _buildSeparator(MenuItemSeparator $item, $postFix)
     {
         $result = '<hr class="separator" />';
 

--- a/src/MenuBuilder/BaseMenuRenderClass.php
+++ b/src/MenuBuilder/BaseMenuRenderClass.php
@@ -112,7 +112,7 @@ class BaseMenuRenderClass implements MenuRenderInterface
 
         $html = $this->format['itemStart'];
 
-        $html .= $this->_buildItem($item, !empty($children) && !empty($this->format['itemWithChildrenPostfix']) ? $this->format['itemWithChildrenPostfix'] : '');
+        $html .= $this->buildItem($item, !empty($children) && !empty($this->format['itemWithChildrenPostfix']) ? $this->format['itemWithChildrenPostfix'] : '');
 
         if (!empty($children)) {
             $enabledChildren = array_filter($children, function (MenuItemInterface $child) {
@@ -135,40 +135,40 @@ class BaseMenuRenderClass implements MenuRenderInterface
     }
 
     /**
-     *  _buildItem method
+     *  buildItem method
      *
      * @param MenuItemInterface $item menu item entity
      * @param string $extLabel additional label elements
      * @return string generated HTML element
      */
-    protected function _buildItem(MenuItemInterface $item, $extLabel)
+    protected function buildItem(MenuItemInterface $item, $extLabel)
     {
         $class = get_class($item);
         // Menu\MenuBuilder\MenuItemLink
         switch ($class) {
             case 'Menu\MenuBuilder\MenuItemPostlink':
-                $result = $this->_buildPostlink($item, $extLabel);
+                $result = $this->buildPostlink($item, $extLabel);
                 break;
             case 'Menu\MenuBuilder\MenuItemButton':
-                $result = $this->_buildButton($item, $extLabel);
+                $result = $this->buildButton($item, $extLabel);
                 break;
             case 'Menu\MenuBuilder\MenuItemSeparator':
-                $result = $this->_buildSeparator($item, $extLabel);
+                $result = $this->buildSeparator($item, $extLabel);
                 break;
             case 'Menu\MenuBuilder\MenuItemLinkButton':
-                $result = $this->_buildLinkButton($item, $extLabel);
+                $result = $this->buildLinkButton($item, $extLabel);
                 break;
             case 'Menu\MenuBuilder\MenuItemPostlinkButton':
-                $result = $this->_buildPostlinkButton($item, $extLabel);
+                $result = $this->buildPostlinkButton($item, $extLabel);
                 break;
             case 'Menu\MenuBuilder\MenuItemLinkButtonModal':
-                $result = $this->_buildLinkButtonModal($item, $extLabel);
+                $result = $this->buildLinkButtonModal($item, $extLabel);
                 break;
             case 'Menu\MenuBuilder\MenuItemLinkModal':
-                $result = $this->_buildLinkModal($item, $extLabel);
+                $result = $this->buildLinkModal($item, $extLabel);
                 break;
             default:
-                $result = $this->_buildLink($item, $extLabel);
+                $result = $this->buildLink($item, $extLabel);
         }
 
         $result .= !empty($item->getRawHtml()) ? $item->getRawHtml() : '';
@@ -177,14 +177,14 @@ class BaseMenuRenderClass implements MenuRenderInterface
     }
 
     /**
-     *  _buildLink method
+     *  buildLink method
      *
      * @param MenuItemInterface $item menu item entity
      * @param string $extLabel additional label elements
      * @param array $params additional params
      * @return string generated HTML element
      */
-    protected function _buildLink(MenuItemInterface $item, $extLabel = '', $params = [])
+    protected function buildLink(MenuItemInterface $item, $extLabel = '', $params = [])
     {
         $params['title'] = __($item->getLabel());
         $params['escape'] = false;
@@ -204,13 +204,13 @@ class BaseMenuRenderClass implements MenuRenderInterface
     }
 
     /**
-     *  _buildLinkButton method
+     *  buildLinkButton method
      *
      * @param MenuItemLinkButton $item menu item entity
      * @param string $extLabel additional label elements
      * @return string generated HTML element
      */
-    protected function _buildLinkButton(MenuItemLinkButton $item, $extLabel)
+    protected function buildLinkButton(MenuItemLinkButton $item, $extLabel)
     {
         $params = ['class' => 'btn btn-default'];
 
@@ -222,35 +222,35 @@ class BaseMenuRenderClass implements MenuRenderInterface
             $params['data-confirm-msg'] = $item->getConfirmMsg();
         }
 
-        return $this->_buildLink($item, $extLabel, $params);
+        return $this->buildLink($item, $extLabel, $params);
     }
 
     /**
-     * _buildLinkButtonModal method
+     * buildLinkButtonModal method
      *
      * @param MenuItemLinkModal $item menu item entity
      * @param string $extLabel additional label elements
      * @param array $params additional params
      * @return string generated HTML element
      */
-    protected function _buildLinkModal(MenuItemLinkModal $item, $extLabel, $params = [])
+    protected function buildLinkModal(MenuItemLinkModal $item, $extLabel, $params = [])
     {
         $item->setUrl('#');
 
         $params['data-toggle'] = 'modal';
         $params['data-target'] = '#' . $item->getModalTarget();
 
-        return $this->_buildLink($item, $extLabel, $params);
+        return $this->buildLink($item, $extLabel, $params);
     }
 
     /**
-     * _buildLinkButtonModal method
+     * buildLinkButtonModal method
      *
      * @param MenuItemLinkButtonModal $item menu item entity
      * @param string $extLabel additional label elements
      * @return string generated HTML element
      */
-    protected function _buildLinkButtonModal(MenuItemLinkButtonModal $item, $extLabel)
+    protected function buildLinkButtonModal(MenuItemLinkButtonModal $item, $extLabel)
     {
         $item->setUrl('#');
 
@@ -258,18 +258,18 @@ class BaseMenuRenderClass implements MenuRenderInterface
             'class' => 'btn btn-default',
         ];
 
-        return $this->_buildLinkModal($item, $extLabel, $params);
+        return $this->buildLinkModal($item, $extLabel, $params);
     }
 
     /**
-     *  _buildPostlink method
+     *  buildPostlink method
      *
      * @param MenuItemPostlink $item menu item entity
      * @param string $postFix additional label elements
      * @param array $params additional params
      * @return string generated HTML element
      */
-    protected function _buildPostlink(MenuItemPostlink $item, $postFix, $params = [])
+    protected function buildPostlink(MenuItemPostlink $item, $postFix, $params = [])
     {
         $params['title'] = $item->getLabel();
         $params['escape'] = false;
@@ -285,27 +285,27 @@ class BaseMenuRenderClass implements MenuRenderInterface
     }
 
     /**
-     *  _buildPostlinkButton method
+     *  buildPostlinkButton method
      *
      * @param MenuItemPostlinkButton $item menu item entity
      * @param string $postFix additional label elements
      * @return string generated HTML element
      */
-    protected function _buildPostlinkButton(MenuItemPostlinkButton $item, $postFix)
+    protected function buildPostlinkButton(MenuItemPostlinkButton $item, $postFix)
     {
         $params['class'] = 'btn btn-default';
 
-        return $this->_buildPostlink($item, $postFix, $params);
+        return $this->buildPostlink($item, $postFix, $params);
     }
 
     /**
-     *  _buildButton method
+     *  buildButton method
      *
      * @param MenuItemButton $item menu item entity
      * @param string $postFix additional label elements
      * @return string generated HTML element
      */
-    protected function _buildButton(MenuItemButton $item, $postFix)
+    protected function buildButton(MenuItemButton $item, $postFix)
     {
         $params = [
             'type' => 'button',
@@ -336,13 +336,13 @@ class BaseMenuRenderClass implements MenuRenderInterface
     }
 
     /**
-     *  _buildSeparator method
+     *  buildSeparator method
      *
      * @param MenuItemSeparator $item menu item entity
      * @param string $postFix additional label elements
      * @return string generated HTML element
      */
-    protected function _buildSeparator(MenuItemSeparator $item, $postFix)
+    protected function buildSeparator(MenuItemSeparator $item, $postFix)
     {
         $result = '<hr class="separator" />';
 

--- a/src/MenuBuilder/BaseMenuRenderClass.php
+++ b/src/MenuBuilder/BaseMenuRenderClass.php
@@ -12,6 +12,8 @@
 namespace Menu\MenuBuilder;
 
 use Cake\View\View;
+use \ReflectionClass;
+use \ReflectionException;
 
 /**
  *  BaseMenuRenderClass class
@@ -145,12 +147,12 @@ class BaseMenuRenderClass implements MenuRenderInterface
     protected function buildItem(MenuItemInterface $item, $extLabel)
     {
         try {
-            $shortClass = (new \ReflectionClass($item))->getShortName();
+            $shortClass = (new ReflectionClass($item))->getShortName();
             $method = str_replace(BaseMenuItem::MENU_ITEM_CLASS_PREFIX, 'build', $shortClass);
             if (!method_exists($this, $method)) {
                 $method = self::DEFAULT_RENDER_METHOD;
             }
-        } catch (\ReflectionException $e) {
+        } catch (ReflectionException $e) {
             $method = self::DEFAULT_RENDER_METHOD;
         }
 

--- a/src/MenuBuilder/BaseMenuRenderClass.php
+++ b/src/MenuBuilder/BaseMenuRenderClass.php
@@ -43,6 +43,19 @@ class BaseMenuRenderClass implements MenuRenderInterface
     protected $noLabel = false;
 
     /**
+     * @var array Mapping between MenuItemInterface implementation and render method
+     */
+    private static $itemRenderer = [
+        'Menu\MenuBuilder\MenuItemPostlink' => 'buildPostlink',
+        'Menu\MenuBuilder\MenuItemButton' => 'buildButton',
+        'Menu\MenuBuilder\MenuItemSeparator' => 'buildSeparator',
+        'Menu\MenuBuilder\MenuItemLinkButton' => 'buildLinkButton',
+        'Menu\MenuBuilder\MenuItemPostlinkButton' => 'buildPostlinkButton',
+        'Menu\MenuBuilder\MenuItemLinkButtonModal' => 'buildLinkButtonModal',
+        'Menu\MenuBuilder\MenuItemLinkModal' => 'buildLinkModal',
+    ];
+
+    /**
      *  __construct method
      *
      * @param \Menu\MenuBuilder\Menu $menu menu to render
@@ -143,32 +156,14 @@ class BaseMenuRenderClass implements MenuRenderInterface
      */
     protected function buildItem(MenuItemInterface $item, $extLabel)
     {
+        $result = null;
+
         $class = get_class($item);
-        // Menu\MenuBuilder\MenuItemLink
-        switch ($class) {
-            case 'Menu\MenuBuilder\MenuItemPostlink':
-                $result = $this->buildPostlink($item, $extLabel);
-                break;
-            case 'Menu\MenuBuilder\MenuItemButton':
-                $result = $this->buildButton($item, $extLabel);
-                break;
-            case 'Menu\MenuBuilder\MenuItemSeparator':
-                $result = $this->buildSeparator($item, $extLabel);
-                break;
-            case 'Menu\MenuBuilder\MenuItemLinkButton':
-                $result = $this->buildLinkButton($item, $extLabel);
-                break;
-            case 'Menu\MenuBuilder\MenuItemPostlinkButton':
-                $result = $this->buildPostlinkButton($item, $extLabel);
-                break;
-            case 'Menu\MenuBuilder\MenuItemLinkButtonModal':
-                $result = $this->buildLinkButtonModal($item, $extLabel);
-                break;
-            case 'Menu\MenuBuilder\MenuItemLinkModal':
-                $result = $this->buildLinkModal($item, $extLabel);
-                break;
-            default:
-                $result = $this->buildLink($item, $extLabel);
+        if (array_key_exists($class, self::$itemRenderer)) {
+            $method = self::$itemRenderer[$class];
+            $result = call_user_func([$this, $method], $item, $extLabel);
+        } else {
+            $result = $this->buildLink($item, $extLabel);
         }
 
         $result .= !empty($item->getRawHtml()) ? $item->getRawHtml() : '';

--- a/src/MenuBuilder/Menu.php
+++ b/src/MenuBuilder/Menu.php
@@ -11,15 +11,14 @@
  */
 namespace Menu\MenuBuilder;
 
-use Menu\MenuBuilder\MenuItem;
-use Menu\MenuBuilder\MenuItemRenderFactory;
-
 /**
  *  Menu class
  *
  */
 class Menu implements MenuInterface
 {
+    use MenuItemContainerTrait;
+
     /**
      * @const MENU_BUTTONS_TYPE
      */
@@ -31,11 +30,6 @@ class Menu implements MenuInterface
     const MENU_ACTIONS_TYPE = 'actions';
 
     /**
-     * @var $menuItems
-     */
-    protected $menuItems = [];
-
-    /**
      *  addMenuItem method
      *
      * @param \Menu\MenuBuilder\MenuItemInterface $item menu item definition
@@ -43,7 +37,7 @@ class Menu implements MenuInterface
      */
     public function addMenuItem($item)
     {
-        array_push($this->menuItems, $item);
+        $this->add($item);
     }
 
     /**
@@ -53,46 +47,6 @@ class Menu implements MenuInterface
      */
     public function getMenuItems()
     {
-        usort($this->menuItems, function ($a, $b) {
-            return $a->getOrder() > $b->getOrder();
-        });
-
-        return $this->menuItems;
-    }
-
-    /**
-     * @inheritdoc
-     *
-     * @param MenuItemInterface $item the menu item to be added
-     * @return void
-     */
-    public function add(MenuItemInterface $item)
-    {
-        $this->addMenuItem($item);
-    }
-
-    /**
-     * @inheritdoc
-     *
-     * @return array List of menu items
-     */
-    public function getAll()
-    {
-        return $this->getMenuItems();
-    }
-
-    /**
-     * Removes the specified menu item from this container.
-     * If the provided item is not in this container, this method does nothing.
-     *
-     * @param MenuItemInterface $item The item to be removed from the menu.
-     * @return void
-     */
-    public function remove(MenuItemInterface $item)
-    {
-        $key = array_search($item, $this->menuItems);
-        if ($key !== false) {
-            unset($this->menuItems[$key]);
-        }
+        return $this->getAll();
     }
 }

--- a/src/MenuBuilder/Menu.php
+++ b/src/MenuBuilder/Menu.php
@@ -28,25 +28,4 @@ class Menu implements MenuInterface
      * @const MENU_ACTIONS_TYPE
      */
     const MENU_ACTIONS_TYPE = 'actions';
-
-    /**
-     *  addMenuItem method
-     *
-     * @param \Menu\MenuBuilder\MenuItemInterface $item menu item definition
-     * @return void
-     */
-    public function addMenuItem($item)
-    {
-        $this->add($item);
-    }
-
-    /**
-     *  getMenuItems method
-     *
-     * @return array of menu items
-     */
-    public function getMenuItems()
-    {
-        return $this->getAll();
-    }
 }

--- a/src/MenuBuilder/Menu.php
+++ b/src/MenuBuilder/Menu.php
@@ -59,4 +59,40 @@ class Menu implements MenuInterface
 
         return $this->menuItems;
     }
+
+    /**
+     * @inheritdoc
+     *
+     * @param MenuItemInterface $item the menu item to be added
+     * @return void
+     */
+    public function add(MenuItemInterface $item)
+    {
+        $this->addMenuItem($item);
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @return array List of menu items
+     */
+    public function getAll()
+    {
+        return $this->getMenuItems();
+    }
+
+    /**
+     * Removes the specified menu item from this container.
+     * If the provided item is not in this container, this method does nothing.
+     *
+     * @param MenuItemInterface $item The item to be removed from the menu.
+     * @return void
+     */
+    public function remove(MenuItemInterface $item)
+    {
+        $key = array_search($item, $this->menuItems);
+        if ($key !== false) {
+            unset($this->menuItems[$key]);
+        }
+    }
 }

--- a/src/MenuBuilder/MenuInterface.php
+++ b/src/MenuBuilder/MenuInterface.php
@@ -18,18 +18,4 @@ namespace Menu\MenuBuilder;
  */
 interface MenuInterface extends MenuItemContainerInterface
 {
-    /**
-     *  addMenuItem method
-     *
-     * @param \Menu\MenuBuilder\MenuItemInterface $item menu item definition
-     * @return void
-     */
-    public function addMenuItem($item);
-
-    /**
-     *  getMenuItems method
-     *
-     * @return array of menu items sorted according to menu item property
-     */
-    public function getMenuItems();
 }

--- a/src/MenuBuilder/MenuInterface.php
+++ b/src/MenuBuilder/MenuInterface.php
@@ -16,7 +16,7 @@ namespace Menu\MenuBuilder;
  *
  * interface for any menu class
  */
-interface MenuInterface
+interface MenuInterface extends MenuItemContainerInterface
 {
     /**
      *  addMenuItem method

--- a/src/MenuBuilder/MenuItemContainerInterface.php
+++ b/src/MenuBuilder/MenuItemContainerInterface.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+
+namespace Menu\MenuBuilder;
+
+/**
+ * Interface MenuItemContainerInterface
+ * Denotes a container of menu items.
+ * Menu items can be added or removed from the container.
+ * @package Menu\MenuBuilder
+ */
+interface MenuItemContainerInterface
+{
+    /**
+     *  Adds the specified menu item to this container
+     *  If the menu item has been part of another menu, removes it from that menu.
+     *
+     * @param MenuItemInterface $item the menu item to be added
+     * @return void
+     */
+    public function add(MenuItemInterface $item);
+
+    /**
+     *  Returns the menu items.
+     *
+     * @return array List of menu items
+     */
+    public function getAll();
+
+    /**
+     * Removes the specified menu item from this container.
+     * If the provided item is not in this container, this method does nothing.
+     *
+     * @param MenuItemInterface $item  The item to be removed from the menu.
+     * @return void
+     */
+    public function remove(MenuItemInterface $item);
+
+    /**
+     * Returns the container or null if this menu container is the outermost container.
+     *
+     * @return MenuItemContainerInterface|null
+     */
+    // public function getParent();
+}

--- a/src/MenuBuilder/MenuItemContainerInterface.php
+++ b/src/MenuBuilder/MenuItemContainerInterface.php
@@ -27,14 +27,14 @@ interface MenuItemContainerInterface
      * @param MenuItemInterface $item the menu item to be added
      * @return void
      */
-    public function add(MenuItemInterface $item);
+    public function addMenuItem(MenuItemInterface $item);
 
     /**
      *  Returns the menu items.
      *
      * @return array List of menu items
      */
-    public function getAll();
+    public function getMenuItems();
 
     /**
      * Removes the specified menu item from this container.
@@ -43,5 +43,5 @@ interface MenuItemContainerInterface
      * @param MenuItemInterface $item  The item to be removed from the menu.
      * @return void
      */
-    public function remove(MenuItemInterface $item);
+    public function removeMenuItem(MenuItemInterface $item);
 }

--- a/src/MenuBuilder/MenuItemContainerTrait.php
+++ b/src/MenuBuilder/MenuItemContainerTrait.php
@@ -54,7 +54,7 @@ trait MenuItemContainerTrait
      */
     public function removeMenuItem(MenuItemInterface $item)
     {
-        $key = array_search($item, $this->menuItems);
+        $key = array_search($item, $this->menuItems, true);
         if ($key !== false) {
             unset($this->menuItems[$key]);
         }

--- a/src/MenuBuilder/MenuItemContainerTrait.php
+++ b/src/MenuBuilder/MenuItemContainerTrait.php
@@ -12,14 +12,13 @@
 
 namespace Menu\MenuBuilder;
 
-/**
- * Interface MenuItemContainerInterface
- * Denotes a container of menu items.
- * Menu items can be added or removed from the container.
- * @package Menu\MenuBuilder
- */
-interface MenuItemContainerInterface
+trait MenuItemContainerTrait
 {
+    /**
+     * @var array List of menu items
+     */
+    private $menuItems = [];
+
     /**
      *  Adds the specified menu item to this container
      *  If the menu item has been part of another menu, removes it from that menu.
@@ -27,14 +26,24 @@ interface MenuItemContainerInterface
      * @param MenuItemInterface $item the menu item to be added
      * @return void
      */
-    public function add(MenuItemInterface $item);
+    public function add(MenuItemInterface $item)
+    {
+        array_push($this->menuItems, $item);
+    }
 
     /**
      *  Returns the menu items.
      *
      * @return array List of menu items
      */
-    public function getAll();
+    public function getAll()
+    {
+        usort($this->menuItems, function ($a, $b) {
+            return $a->getOrder() > $b->getOrder();
+        });
+
+        return $this->menuItems;
+    }
 
     /**
      * Removes the specified menu item from this container.
@@ -43,5 +52,11 @@ interface MenuItemContainerInterface
      * @param MenuItemInterface $item  The item to be removed from the menu.
      * @return void
      */
-    public function remove(MenuItemInterface $item);
+    public function remove(MenuItemInterface $item)
+    {
+        $key = array_search($item, $this->menuItems);
+        if ($key !== false) {
+            unset($this->menuItems[$key]);
+        }
+    }
 }

--- a/src/MenuBuilder/MenuItemContainerTrait.php
+++ b/src/MenuBuilder/MenuItemContainerTrait.php
@@ -26,7 +26,7 @@ trait MenuItemContainerTrait
      * @param MenuItemInterface $item the menu item to be added
      * @return void
      */
-    public function add(MenuItemInterface $item)
+    public function addMenuItem(MenuItemInterface $item)
     {
         array_push($this->menuItems, $item);
     }
@@ -36,7 +36,7 @@ trait MenuItemContainerTrait
      *
      * @return array List of menu items
      */
-    public function getAll()
+    public function getMenuItems()
     {
         usort($this->menuItems, function ($a, $b) {
             return $a->getOrder() > $b->getOrder();
@@ -52,7 +52,7 @@ trait MenuItemContainerTrait
      * @param MenuItemInterface $item  The item to be removed from the menu.
      * @return void
      */
-    public function remove(MenuItemInterface $item)
+    public function removeMenuItem(MenuItemInterface $item)
     {
         $key = array_search($item, $this->menuItems);
         if ($key !== false) {

--- a/src/MenuBuilder/MenuItemFactory.php
+++ b/src/MenuBuilder/MenuItemFactory.php
@@ -34,7 +34,7 @@ final class MenuItemFactory
             if ($key == 'children') {
                 foreach ($value as $k => $v) {
                     $childItem = static::createMenuItem($v);
-                    $menuItem->addChild($childItem);
+                    $menuItem->addMenuItem($childItem);
                 }
             } else {
                 $method = 'set' . ucfirst(Inflector::camelize($key));

--- a/src/MenuBuilder/MenuItemInterface.php
+++ b/src/MenuBuilder/MenuItemInterface.php
@@ -16,7 +16,7 @@ namespace Menu\MenuBuilder;
  *
  * interface for all menu item classes
  */
-interface MenuItemInterface
+interface MenuItemInterface extends MenuItemContainerInterface
 {
 
     /**

--- a/src/MenuBuilder/MenuItemInterface.php
+++ b/src/MenuBuilder/MenuItemInterface.php
@@ -22,6 +22,7 @@ interface MenuItemInterface extends MenuItemContainerInterface
     /**
      *  getChildren method
      *
+     * @deprecated Use getMenuItems method instead.
      * @return array list of child items
      */
     public function getChildren();
@@ -30,6 +31,7 @@ interface MenuItemInterface extends MenuItemContainerInterface
      *  addChild method
      *
      * @param MenuItemInterface $item menu item
+     * @deprecated Use addMenuItem method instead.
      * @return void
      */
     public function addChild(MenuItemInterface $item);
@@ -38,6 +40,7 @@ interface MenuItemInterface extends MenuItemContainerInterface
      * removeChild method
      *
      * @param string $childId to identify child item to be removed
+     * @deprecated Use removeMenuItem method instead.
      * @return void
      */
     public function removeChild($childId);

--- a/src/MenuBuilder/MenuItemInterface.php
+++ b/src/MenuBuilder/MenuItemInterface.php
@@ -79,4 +79,119 @@ interface MenuItemInterface extends MenuItemContainerInterface
      * @return bool
      */
     public function isEnabled();
+
+    /**
+     * Gets the text label for this menu item.
+     *
+     * @return string the label of this menu item, or null if this menu item has no label.
+     */
+    public function getLabel();
+
+    /**
+     * Sets the text label for this menu item to the specified label.
+     *
+     * @param string $label the new label, or null for no label.
+     * @return void
+     */
+    public function setLabel($label);
+
+    /**
+     * Gets the icon for this menu item.
+     *
+     * @return string the icon of this menu item, or null if this menu item has no icon.
+     */
+    public function getIcon();
+
+    /**
+     * Sets the icon for this menu item to the specified icon.
+     * The specified icon can be any CSS Icon name as provided by an icon library, like Font Awesome.
+     *
+     * @param string $icon the new icon, or null for no icon.
+     * @return void
+     */
+    public function setIcon($icon);
+
+    /**
+     * Gets the text description for this menu item.
+     *
+     * @return string the description of this menu item, or null if this menu item has no description.
+     */
+    public function getDescription();
+
+    /**
+     * Sets the text description for this menu item to the specified description.
+     *
+     * @param string $descr the new description, or null for no description.
+     * @return void
+     */
+    public function setDescription($descr);
+
+    /**
+     * Gets the URL for this menu item.
+     *
+     * @return string|array the URL of this menu item, or null if this menu item has no URL.
+     */
+    public function getUrl();
+
+    /**
+     * Sets the URL for this menu item to the specified URL.
+     *
+     * @param string|array $url the new URL, or null for no URL.
+     * @return void
+     */
+    public function setUrl($url);
+
+    /**
+     * Gets the order position for this menu item.
+     * Default position is 0.
+     *
+     * @return int the position of this menu item.
+     */
+    public function getOrder();
+
+    /**
+     * Sets the order position for this menu item to the specified order.
+     *
+     * @param int $order the new position.
+     * @return void
+     */
+    public function setOrder($order);
+
+    /**
+     * Gets the target for this menu item.
+     * Default target is _self
+     *
+     * @return string the target of this menu item.
+     */
+    public function getTarget();
+
+    /**
+     * Sets target for this menu item to the specified target.
+     * Default target is _self
+     * The specified target can be one of the following:
+     * - _self      Load in the same frame as it was clicked
+     * - _blank     Load in a new window
+     * - _parent    Load in the parent frameset
+     * - _top       Load in the full body of the window
+     * - framename  Load in a named frame
+     *
+     * @param string $target the new target.
+     * @return void
+     */
+    public function setTarget($target);
+
+    /**
+     * Returns the raw HTML for this menu item.
+     *
+     * @return string the raw HTML for this menu item, or null if no HTML was provided.
+     */
+    public function getRawHtml();
+
+    /**
+     * Sets the raw HTML for this menu item to the specified HTML.
+     *
+     * @param string $rawHtml the new HTML, or null for no HTML.
+     * @return void
+     */
+    public function setRawHtml($rawHtml);
 }

--- a/tests/TestCase/MenuBuilder/BaseMenuRenderClassTest.php
+++ b/tests/TestCase/MenuBuilder/BaseMenuRenderClassTest.php
@@ -92,7 +92,7 @@ class BaseMenuRenderClassTest extends TestCase
         $subitem->setUrl('http://example.com');
         $subitem->setLabel('SubLink');
         $subitem->disable();
-        $item->addChild($subitem);
+        $item->addMenuItem($subitem);
 
         $html = $this->menuRenderer->render();
         $this->assertStringStartsWith('<ul><li><a', $html);

--- a/tests/TestCase/MenuBuilder/MenuItemButtonTest.php
+++ b/tests/TestCase/MenuBuilder/MenuItemButtonTest.php
@@ -178,8 +178,8 @@ class MenuItemButtonTest extends TestCase
      */
     public function testAddChild($data, $expected, $msg)
     {
-        $this->menuItem->addChild($data);
-        $this->assertEquals($expected, $this->menuItem->getChildren(), $msg);
+        $this->menuItem->addMenuItem($data);
+        $this->assertEquals($expected, $this->menuItem->getMenuItems(), $msg);
     }
 
     public function providerButtonChildren()

--- a/tests/TestCase/MenuBuilder/MenuTest.php
+++ b/tests/TestCase/MenuBuilder/MenuTest.php
@@ -7,6 +7,9 @@ use Menu\MenuBuilder\MenuItemButton;
 
 class MenuTest extends TestCase
 {
+    /**
+     * @var Menu
+     */
     public $instance;
 
     public function setUp()
@@ -29,6 +32,19 @@ class MenuTest extends TestCase
 
         $result = $this->instance->getMenuItems();
         $this->assertEquals($result, $expected, $msg);
+    }
+
+    public function testAddRemove()
+    {
+        $item = new MenuItemButton();
+        $this->instance->addMenuItem($item);
+        $this->assertEquals(1, count($this->instance->getMenuItems()));
+
+        $this->instance->removeMenuItem(new MenuItemButton());
+        $this->assertEquals(1, count($this->instance->getMenuItems()));
+
+        $this->instance->removeMenuItem($item);
+        $this->assertEquals(0, count($this->instance->getMenuItems()));
     }
 
     public function providerMenuItems()


### PR DESCRIPTION
This part of the work required for task #809 

* Add MenuItemContainerInterface to consolidate methods between MenuItemInterface and MenuInterface
* Provide a default implementation (trait)  for MenuItemContainerInterface
* Define common setters and getters under MenuItemInterface
* Improve type hinting for MenuItemInterface implementations  …
* Deprecate MenuInterface::addChild, MenuInterface::getChildren and MenuInterface::removeChild
* Add tests for removeMenuItem method