### PR TITLE
Hide menu items having no enabled children (task #6865)

### DIFF
--- a/src/MenuBuilder/BaseMenuItem.php
+++ b/src/MenuBuilder/BaseMenuItem.php
@@ -399,6 +399,18 @@ abstract class BaseMenuItem implements MenuItemInterface
             }
         }
 
+        // Parent menu items are enabled only and only if they have at least one child enabled
+        if (!empty($this->menuItems)) {
+            /** @var MenuItemInterface $menuItem */
+            foreach ($this->menuItems as $menuItem) {
+                if ($menuItem->isEnabled()) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         return true;
     }
 }

--- a/src/MenuBuilder/MenuItemInterface.php
+++ b/src/MenuBuilder/MenuItemInterface.php
@@ -79,6 +79,7 @@ interface MenuItemInterface extends MenuItemContainerInterface
      * Returns true only and only if:
      * - enabled flag is set to true
      * - all defined conditions are being evaluated to false
+     * - if having child menu items, one of them is enabled
      * @return bool
      */
     public function isEnabled();

--- a/tests/TestCase/MenuBuilder/BaseMenuRenderClassTest.php
+++ b/tests/TestCase/MenuBuilder/BaseMenuRenderClassTest.php
@@ -94,9 +94,8 @@ class BaseMenuRenderClassTest extends TestCase
         $subitem->disable();
         $item->addMenuItem($subitem);
 
-        $html = $this->menuRenderer->render();
-        $this->assertStringStartsWith('<ul><li><a', $html);
-        $this->assertStringEndsWith('<ul></ul></li></ul>', $html);
+        $expected = '<ul></ul>';
+        $this->assertEquals($expected, $this->menuRenderer->render());
     }
 
     public function testRenderMenuWithButton()

--- a/tests/TestCase/MenuBuilder/MenuItemButtonTest.php
+++ b/tests/TestCase/MenuBuilder/MenuItemButtonTest.php
@@ -4,6 +4,7 @@ namespace Menu\Test\TestCase\MenuBuilder;
 use Cake\TestSuite\TestCase;
 use Menu\MenuBuilder\BaseMenuItem;
 use Menu\MenuBuilder\MenuItemButton;
+use Menu\Model\Entity\MenuItem;
 
 class MenuItemButtonTest extends TestCase
 {
@@ -200,6 +201,7 @@ class MenuItemButtonTest extends TestCase
         $item->enable();
         $this->assertTrue($item->isEnabled());
     }
+
     public function testConditions()
     {
         $item = new MenuItemButton();
@@ -210,6 +212,22 @@ class MenuItemButtonTest extends TestCase
         $item->disableIf(function () {
             return true;
         });
+        $this->assertFalse($item->isEnabled());
+    }
+
+    public function testEnabledFlagNested()
+    {
+        $child1 = new MenuItemButton();
+
+        $child2 = new MenuItemButton();
+        $child2->disable();
+
+        $item = new MenuItemButton();
+        $item->addMenuItem($child1);
+        $item->addMenuItem($child2);
+        $this->assertTrue($item->isEnabled());
+
+        $child1->disable();
         $this->assertFalse($item->isEnabled());
     }
 }


### PR DESCRIPTION
Parent menu items are enabled only and only if they have at least one child enabled