### PR TITLE
Custom HTML attributes for Menu Items (task #809)

### DIFF
--- a/src/MenuBuilder/BaseMenuItem.php
+++ b/src/MenuBuilder/BaseMenuItem.php
@@ -90,6 +90,11 @@ abstract class BaseMenuItem implements MenuItemInterface
     private $conditions = [];
 
     /**
+     * @var array List of attributes to be included in menu item link or button
+     */
+    private $attributes = [];
+
+    /**
      * @inheritdoc
      *
      * @return string the label of this menu item, or null if this menu item has no label.
@@ -412,5 +417,28 @@ abstract class BaseMenuItem implements MenuItemInterface
         }
 
         return true;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @param string $attributeName Attribute's name
+     * @param string $attributeValue Attribute's value
+     * @return void
+     */
+    public function addAttribute($attributeName, $attributeValue)
+    {
+        $this->attributes[$attributeName] = $attributeValue;
+    }
+
+    /**
+     * Returns an associative array including all the defined attributes.
+     * The array's key defines the attribute name.
+     *
+     * @return array
+     */
+    public function getAttributes()
+    {
+        return $this->attributes;
     }
 }

--- a/src/MenuBuilder/BaseMenuRenderClass.php
+++ b/src/MenuBuilder/BaseMenuRenderClass.php
@@ -156,7 +156,7 @@ class BaseMenuRenderClass implements MenuRenderInterface
             $method = self::DEFAULT_RENDER_METHOD;
         }
 
-        $result = call_user_func([$this, $method], $item, $extLabel);
+        $result = call_user_func([$this, $method], $item, $extLabel, $item->getAttributes());
         $result .= !empty($item->getRawHtml()) ? $item->getRawHtml() : '';
 
         return $result;
@@ -167,7 +167,7 @@ class BaseMenuRenderClass implements MenuRenderInterface
      *
      * @param MenuItemInterface $item menu item entity
      * @param string $extLabel additional label elements
-     * @param array $params additional params
+     * @param array $params HTML attributes
      * @return string generated HTML element
      */
     protected function buildLink(MenuItemInterface $item, $extLabel = '', $params = [])
@@ -194,11 +194,14 @@ class BaseMenuRenderClass implements MenuRenderInterface
      *
      * @param MenuItemLinkButton $item menu item entity
      * @param string $extLabel additional label elements
+     * @param array $params HTML attributes
      * @return string generated HTML element
      */
-    protected function buildLinkButton(MenuItemLinkButton $item, $extLabel)
+    protected function buildLinkButton(MenuItemLinkButton $item, $extLabel, $params = [])
     {
-        $params = ['class' => 'btn btn-default'];
+        if (empty($params['class'])) {
+            $params['class'] = 'btn btn-default';
+        }
 
         if (!empty($item->getDataType())) {
             $params['data-type'] = $item->getDataType();
@@ -216,7 +219,7 @@ class BaseMenuRenderClass implements MenuRenderInterface
      *
      * @param MenuItemLinkModal $item menu item entity
      * @param string $extLabel additional label elements
-     * @param array $params additional params
+     * @param array $params HTML attributes
      * @return string generated HTML element
      */
     protected function buildLinkModal(MenuItemLinkModal $item, $extLabel, $params = [])
@@ -234,15 +237,16 @@ class BaseMenuRenderClass implements MenuRenderInterface
      *
      * @param MenuItemLinkButtonModal $item menu item entity
      * @param string $extLabel additional label elements
+     * @param array $params HTML attributes
      * @return string generated HTML element
      */
-    protected function buildLinkButtonModal(MenuItemLinkButtonModal $item, $extLabel)
+    protected function buildLinkButtonModal(MenuItemLinkButtonModal $item, $extLabel, $params = [])
     {
         $item->setUrl('#');
 
-        $params = [
-            'class' => 'btn btn-default',
-        ];
+        if (empty($params['class'])) {
+            $params['class'] = 'btn btn-default';
+        }
 
         return $this->buildLinkModal($item, $extLabel, $params);
     }
@@ -252,7 +256,7 @@ class BaseMenuRenderClass implements MenuRenderInterface
      *
      * @param MenuItemPostlink $item menu item entity
      * @param string $postFix additional label elements
-     * @param array $params additional params
+     * @param array $params HTML attributes
      * @return string generated HTML element
      */
     protected function buildPostlink(MenuItemPostlink $item, $postFix, $params = [])
@@ -275,11 +279,14 @@ class BaseMenuRenderClass implements MenuRenderInterface
      *
      * @param MenuItemPostlinkButton $item menu item entity
      * @param string $postFix additional label elements
+     * @param array $params HTML attributes
      * @return string generated HTML element
      */
-    protected function buildPostlinkButton(MenuItemPostlinkButton $item, $postFix)
+    protected function buildPostlinkButton(MenuItemPostlinkButton $item, $postFix, $params = [])
     {
-        $params['class'] = 'btn btn-default';
+        if (empty($params['class'])) {
+            $params['class'] = 'btn btn-default';
+        }
 
         return $this->buildPostlink($item, $postFix, $params);
     }
@@ -291,11 +298,13 @@ class BaseMenuRenderClass implements MenuRenderInterface
      * @param string $postFix additional label elements
      * @return string generated HTML element
      */
-    protected function buildButton(MenuItemButton $item, $postFix)
+    protected function buildButton(MenuItemButton $item, $postFix, $params = [])
     {
-        $params = [
-            'type' => 'button',
-        ];
+        $params['type'] = 'button';
+
+        if (empty($params['class'])) {
+            $params['class'] = 'btn btn-default';
+        }
 
         if (!empty($item->getExtraAttribute())) {
             $params['class'] = $item->getExtraAttribute();
@@ -316,9 +325,7 @@ class BaseMenuRenderClass implements MenuRenderInterface
             $label .= ' ' . $this->format['itemLabelPostfix'];
         }
 
-        $result = '<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">' . $label . '</button>';
-
-        return $result;
+        return $this->viewEntity->Html->tag('button', $label, $params);
     }
 
     /**

--- a/src/MenuBuilder/MenuButtonsRender.php
+++ b/src/MenuBuilder/MenuButtonsRender.php
@@ -39,7 +39,7 @@ class MenuButtonsRender extends BaseMenuRenderClass
             'itemEnd' => '',
             'childItemStart' => '<li>',
             'childItemEnd' => '</li>',
-            'itemWithChildrenStart' => '<div class="btn-group btn-group-sm">',
+            'itemWithChildrenStart' => '<div class="btn-group btn-group-sm dropdown-toggle">',
             'itemWithChildrenEnd' => '</div>',
             'itemLabelPostfix' => '<span class="caret"></span>',
         ];

--- a/src/MenuBuilder/MenuItemFactory.php
+++ b/src/MenuBuilder/MenuItemFactory.php
@@ -36,6 +36,10 @@ final class MenuItemFactory
                     $childItem = static::createMenuItem($v);
                     $menuItem->addMenuItem($childItem);
                 }
+            } elseif ($key == 'attributes') {
+                foreach ($value as $k => $v) {
+                    $menuItem->addAttribute($k, $v);
+                }
             } else {
                 $method = 'set' . ucfirst(Inflector::camelize($key));
                 if (method_exists($menuItem, $method)) {

--- a/src/MenuBuilder/MenuItemInterface.php
+++ b/src/MenuBuilder/MenuItemInterface.php
@@ -198,4 +198,22 @@ interface MenuItemInterface extends MenuItemContainerInterface
      * @return void
      */
     public function setRawHtml($rawHtml);
+
+    /**
+     * Adds an HTML attribute for this menu item.
+     * If the attribute already exists it will be overwritten.
+     *
+     * @param string $attributeName Attribute's name
+     * @param string $attributeValue Attribute's value
+     * @return void
+     */
+    public function addAttribute($attributeName, $attributeValue);
+
+    /**
+     * Returns an associative array including all the defined attributes.
+     * The array's key defines the attribute name.
+     *
+     * @return array
+     */
+    public function getAttributes();
 }

--- a/src/View/Cell/MenuCell.php
+++ b/src/View/Cell/MenuCell.php
@@ -14,6 +14,7 @@ namespace Menu\View\Cell;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
 use Cake\View\Cell;
+use Exception;
 use InvalidArgumentException;
 use Menu\Event\EventName;
 use Menu\MenuBuilder\Menu;
@@ -85,11 +86,16 @@ class MenuCell extends Cell
         $this->fullBaseUrl = (bool)$fullBaseUrl;
 
         // get menu
-        $menu = $this->Menus->findByName($name)->firstOrFail();
+        try {
+            $menu = $this->Menus->findByName($name)->firstOrFail();
 
-        $menuItems = $menu->default ?
-            $this->_getMenuItemsFromEvent($menu) :
-            $this->_getMenuItemsFromTable($menu);
+            $menuItems = $menu->default ?
+                $this->_getMenuItemsFromEvent($name) :
+                $this->_getMenuItemsFromTable($menu);
+        } catch (Exception $e) {
+            $menuItems = $this->_getMenuItemsFromEvent($name);
+        }
+
 
         // maintain backwards compatibility for menu arrays
         if (is_array($menuItems)) {
@@ -112,10 +118,10 @@ class MenuCell extends Cell
      * @param array $modules Modules to fetch menu items for
      * @return array
      */
-    protected function _getMenuItemsFromEvent(EntityInterface $menu, array $modules = [])
+    protected function _getMenuItemsFromEvent($menuName, array $modules = [])
     {
         $event = new Event((string)EventName::GET_MENU_ITEMS(), $this, [
-            'name' => $menu->name,
+            'name' => $menuName,
             'user' => $this->user,
             'fullBaseUrl' => $this->fullBaseUrl,
             'modules' => $modules

--- a/src/View/Cell/MenuCell.php
+++ b/src/View/Cell/MenuCell.php
@@ -96,7 +96,6 @@ class MenuCell extends Cell
             $menuItems = $this->_getMenuItemsFromEvent($name);
         }
 
-
         // maintain backwards compatibility for menu arrays
         if (is_array($menuItems)) {
             $menuItems = $this->_normalizeItems($menuItems);

--- a/src/View/Cell/MenuCell.php
+++ b/src/View/Cell/MenuCell.php
@@ -114,7 +114,7 @@ class MenuCell extends Cell
     /**
      * Menu items getter using Event.
      *
-     * @param \Cake\Datasource\EntityInterface $menu Menu entity
+     * @param string $menuName Menu name
      * @param array $modules Modules to fetch menu items for
      * @return array
      */
@@ -192,7 +192,7 @@ class MenuCell extends Cell
         }
 
         if (static::TYPE_MODULE === $type) {
-            $item = $this->_getMenuItemsFromEvent($menu, [$item['url']]);
+            $item = $this->_getMenuItemsFromEvent($menu->get('name'), [$item['url']]);
             reset($item);
             $item = current($item);
         }

--- a/tests/TestCase/MenuBuilder/BaseMenuRenderClassTest.php
+++ b/tests/TestCase/MenuBuilder/BaseMenuRenderClassTest.php
@@ -106,7 +106,7 @@ class BaseMenuRenderClassTest extends TestCase
 
         $this->menu->addMenuItem($item);
 
-        $expected = '<ul><li><button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Button</button></li></ul>';
+        $expected = '<ul><li><button type="button" class="btn btn-default">Button</button></li></ul>';
 
         $this->assertEquals($expected, $this->menuRenderer->render());
     }


### PR DESCRIPTION
* Allows to use Menu cell even if the menu does not exist in database (useful for completely dynamic menus)
* Extends Menu Interface / Builder to support custom HTML attributes
* Extends Renderer to include custom HTML attributes for generated HTML
* Uses CakePHP view helpers to render html