### PR TITLE
Fix PHPStan errors (task #8284)

### DIFF
--- a/src/Controller/MenuItemsController.php
+++ b/src/Controller/MenuItemsController.php
@@ -13,6 +13,8 @@ namespace Menu\Controller;
 
 use Cake\Core\Configure;
 use Cake\Event\Event;
+use Cake\Http\Response;
+use Cake\ORM\TableRegistry;
 use Menu\Controller\AppController;
 use Qobo\Utils\Utility;
 
@@ -39,14 +41,14 @@ class MenuItemsController extends AppController
      * Add method
      *
      * @param string $menuId Menu id
-     * @return \Cake\Http\Response|void Redirects on successful add, renders view otherwise.
+     * @return \Cake\Http\Response|null Redirects on successful add, renders view otherwise.
      */
-    public function add(string $menuId)
+    public function add(string $menuId): ?Response
     {
-        $menu = $this->MenuItems->Menus->get($menuId);
+        $menu = TableRegistry::get('Menus')->get($menuId);
         $menuItem = $this->MenuItems->newEntity();
         if ($this->request->is('post')) {
-            $data = $this->request->data;
+            $data = $this->request->getData();
             $data['menu_id'] = $menu->id;
             $menuItem = $this->MenuItems->patchEntity($menuItem, $data);
             if ($this->MenuItems->save($menuItem)) {
@@ -70,20 +72,21 @@ class MenuItemsController extends AppController
      * Edit method
      *
      * @param string|null $id Menu Item id.
-     * @return \Cake\Http\Response|void Redirects on successful edit, renders view otherwise.
+     * @return \Cake\Http\Response|null Redirects on successful edit, renders view otherwise.
      * @throws \Cake\Http\Exception\NotFoundException When record not found.
      */
-    public function edit(string $id = null)
+    public function edit(string $id = null): ?Response
     {
         $menuItem = $this->MenuItems->get($id, [
             'contain' => ['Menus']
         ]);
         if ($this->request->is(['patch', 'post', 'put'])) {
-            $menuItem = $this->MenuItems->patchEntity($menuItem, $this->request->data);
+            $data = (array)$this->request->getData();
+            $menuItem = $this->MenuItems->patchEntity($menuItem, $data);
             if ($this->MenuItems->save($menuItem)) {
                 $this->Flash->success(__('The menu item has been saved.'));
 
-                return $this->redirect(['controller' => 'Menus', 'action' => 'view', $menuItem->menu->id]);
+                return $this->redirect(['controller' => 'Menus', 'action' => 'view', $menuItem->get('menu')->get('id')]);
             } else {
                 $this->Flash->error(__('The menu item could not be saved. Please, try again.'));
             }
@@ -91,7 +94,7 @@ class MenuItemsController extends AppController
 
         $parentMenuItems = $this->MenuItems
             ->find('treeList', ['spacer' => self::TREE_SPACER])
-            ->where(['MenuItems.menu_id' => $menuItem->menu->id, 'MenuItems.id !=' => $id]);
+            ->where(['MenuItems.menu_id' => $menuItem->get('menu')->get('id'), 'MenuItems.id !=' => $id]);
 
         $this->set(compact('menuItem', 'parentMenuItems'));
         $this->set('_serialize', ['menuItem']);
@@ -104,7 +107,7 @@ class MenuItemsController extends AppController
      * @return \Cake\Http\Response|null Redirects to index.
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
-    public function delete(string $id = null)
+    public function delete(string $id = null): ?Response
     {
         $this->request->allowMethod(['post', 'delete']);
         $menuItem = $this->MenuItems->get($id);
@@ -122,10 +125,9 @@ class MenuItemsController extends AppController
      *
      * @param  string $id menu id
      * @param  string $action move action
-     * @throws InvalidPrimaryKeyException When provided id is invalid.
      * @return \Cake\Http\Response|null Redirects to index or referer.
      */
-    public function moveNode(string $id = null, string $action = '')
+    public function moveNode(string $id = null, string $action = ''): ?Response
     {
         $moveActions = ['up', 'down'];
         if (!in_array($action, $moveActions)) {
@@ -136,9 +138,9 @@ class MenuItemsController extends AppController
         $menuItem = $this->MenuItems->get($id);
         $moveFunction = 'move' . $action;
         if ($this->MenuItems->{$moveFunction}($menuItem)) {
-            $this->Flash->success(__('{0} has been moved {1} successfully.', $menuItem->label, $action));
+            $this->Flash->success(__('{0} has been moved {1} successfully.', $menuItem->get('label'), $action));
         } else {
-            $this->Flash->error(__('Fail to move {0} {1}.', $menuItem->label, $action));
+            $this->Flash->error(__('Fail to move {0} {1}.', $menuItem->get('label'), $action));
         }
 
         return $this->redirect($this->referer());

--- a/src/Controller/MenuItemsController.php
+++ b/src/Controller/MenuItemsController.php
@@ -41,11 +41,11 @@ class MenuItemsController extends AppController
      * Add method
      *
      * @param string $menuId Menu id
-     * @return \Cake\Http\Response|null Redirects on successful add, renders view otherwise.
+     * @return void Redirects on successful add, renders view otherwise.
      */
-    public function add(string $menuId): ?Response
+    public function add(string $menuId): void
     {
-        $menu = TableRegistry::get('Menus')->get($menuId);
+        $menu = TableRegistry::get('Menu.Menus')->get($menuId);
         $menuItem = $this->MenuItems->newEntity();
         if ($this->request->is('post')) {
             $data = $this->request->getData();
@@ -54,7 +54,8 @@ class MenuItemsController extends AppController
             if ($this->MenuItems->save($menuItem)) {
                 $this->Flash->success(__('The menu item has been saved.'));
 
-                return $this->redirect(['controller' => 'Menus', 'action' => 'view', $menu->id]);
+                $this->redirect(['controller' => 'Menus', 'action' => 'view', $menu->id]);
+                return;
             } else {
                 $this->Flash->error(__('The menu item could not be saved. Please, try again.'));
             }
@@ -72,10 +73,10 @@ class MenuItemsController extends AppController
      * Edit method
      *
      * @param string|null $id Menu Item id.
-     * @return \Cake\Http\Response|null Redirects on successful edit, renders view otherwise.
+     * @return void Redirects on successful edit, renders view otherwise.
      * @throws \Cake\Http\Exception\NotFoundException When record not found.
      */
-    public function edit(string $id = null): ?Response
+    public function edit(string $id = null): void
     {
         $menuItem = $this->MenuItems->get($id, [
             'contain' => ['Menus']
@@ -85,8 +86,9 @@ class MenuItemsController extends AppController
             $menuItem = $this->MenuItems->patchEntity($menuItem, $data);
             if ($this->MenuItems->save($menuItem)) {
                 $this->Flash->success(__('The menu item has been saved.'));
+                $this->redirect(['controller' => 'Menus', 'action' => 'view', $menuItem->get('menu')->get('id')]);
 
-                return $this->redirect(['controller' => 'Menus', 'action' => 'view', $menuItem->get('menu')->get('id')]);
+                return;
             } else {
                 $this->Flash->error(__('The menu item could not be saved. Please, try again.'));
             }
@@ -104,10 +106,10 @@ class MenuItemsController extends AppController
      * Delete method
      *
      * @param string|null $id Menu Item id.
-     * @return \Cake\Http\Response|null Redirects to index.
+     * @return void Redirects to index.
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
-    public function delete(string $id = null): ?Response
+    public function delete(string $id = null): void
     {
         $this->request->allowMethod(['post', 'delete']);
         $menuItem = $this->MenuItems->get($id);
@@ -117,7 +119,7 @@ class MenuItemsController extends AppController
             $this->Flash->error(__('The menu item could not be deleted. Please, try again.'));
         }
 
-        return $this->redirect($this->referer());
+        $this->redirect($this->referer());
     }
 
     /**
@@ -125,15 +127,16 @@ class MenuItemsController extends AppController
      *
      * @param  string $id menu id
      * @param  string $action move action
-     * @return \Cake\Http\Response|null Redirects to index or referer.
+     * @return void Redirects to index or referer.
      */
-    public function moveNode(string $id = null, string $action = ''): ?Response
+    public function moveNode(string $id = null, string $action = ''): void
     {
         $moveActions = ['up', 'down'];
         if (!in_array($action, $moveActions)) {
             $this->Flash->error(__('Unknown move action.'));
+            $this->redirect(['action' => 'index']);
 
-            return $this->redirect(['action' => 'index']);
+            return;
         }
         $menuItem = $this->MenuItems->get($id);
         $moveFunction = 'move' . $action;
@@ -143,6 +146,6 @@ class MenuItemsController extends AppController
             $this->Flash->error(__('Fail to move {0} {1}.', $menuItem->get('label'), $action));
         }
 
-        return $this->redirect($this->referer());
+        $this->redirect($this->referer());
     }
 }

--- a/src/Controller/MenuItemsController.php
+++ b/src/Controller/MenuItemsController.php
@@ -54,6 +54,7 @@ class MenuItemsController extends AppController
                 $this->Flash->success((string)__('The menu item has been saved.'));
 
                 $this->redirect(['controller' => 'Menus', 'action' => 'view', $menu->id]);
+
                 return;
             } else {
                 $this->Flash->error((string)__('The menu item could not be saved. Please, try again.'));

--- a/src/Controller/MenuItemsController.php
+++ b/src/Controller/MenuItemsController.php
@@ -13,7 +13,6 @@ namespace Menu\Controller;
 
 use Cake\Core\Configure;
 use Cake\Event\Event;
-use Cake\Http\Response;
 use Cake\ORM\TableRegistry;
 use Menu\Controller\AppController;
 use Qobo\Utils\Utility;
@@ -52,12 +51,13 @@ class MenuItemsController extends AppController
             $data['menu_id'] = $menu->id;
             $menuItem = $this->MenuItems->patchEntity($menuItem, $data);
             if ($this->MenuItems->save($menuItem)) {
-                $this->Flash->success(__('The menu item has been saved.'));
+                $this->Flash->success((string)__('The menu item has been saved.'));
 
                 $this->redirect(['controller' => 'Menus', 'action' => 'view', $menu->id]);
                 return;
             } else {
-                $this->Flash->error(__('The menu item could not be saved. Please, try again.'));
+                $this->Flash->error((string)__('The menu item could not be saved. Please, try again.'));
+                $this->Flash->error((string)__('The menu item could not be saved. Please, try again.'));
             }
         }
 
@@ -85,12 +85,12 @@ class MenuItemsController extends AppController
             $data = (array)$this->request->getData();
             $menuItem = $this->MenuItems->patchEntity($menuItem, $data);
             if ($this->MenuItems->save($menuItem)) {
-                $this->Flash->success(__('The menu item has been saved.'));
+                $this->Flash->success((string)__('The menu item has been saved.'));
                 $this->redirect(['controller' => 'Menus', 'action' => 'view', $menuItem->get('menu')->get('id')]);
 
                 return;
             } else {
-                $this->Flash->error(__('The menu item could not be saved. Please, try again.'));
+                $this->Flash->error((string)__('The menu item could not be saved. Please, try again.'));
             }
         }
 
@@ -114,9 +114,9 @@ class MenuItemsController extends AppController
         $this->request->allowMethod(['post', 'delete']);
         $menuItem = $this->MenuItems->get($id);
         if ($this->MenuItems->delete($menuItem)) {
-            $this->Flash->success(__('The menu item has been deleted.'));
+            $this->Flash->success((string)__('The menu item has been deleted.'));
         } else {
-            $this->Flash->error(__('The menu item could not be deleted. Please, try again.'));
+            $this->Flash->error((string)__('The menu item could not be deleted. Please, try again.'));
         }
 
         $this->redirect($this->referer());
@@ -133,7 +133,7 @@ class MenuItemsController extends AppController
     {
         $moveActions = ['up', 'down'];
         if (!in_array($action, $moveActions)) {
-            $this->Flash->error(__('Unknown move action.'));
+            $this->Flash->error((string)__('Unknown move action.'));
             $this->redirect(['action' => 'index']);
 
             return;
@@ -141,9 +141,9 @@ class MenuItemsController extends AppController
         $menuItem = $this->MenuItems->get($id);
         $moveFunction = 'move' . $action;
         if ($this->MenuItems->{$moveFunction}($menuItem)) {
-            $this->Flash->success(__('{0} has been moved {1} successfully.', $menuItem->get('label'), $action));
+            $this->Flash->success((string)__('{0} has been moved {1} successfully.', $menuItem->get('label'), $action));
         } else {
-            $this->Flash->error(__('Fail to move {0} {1}.', $menuItem->get('label'), $action));
+            $this->Flash->error((string)__('Fail to move {0} {1}.', $menuItem->get('label'), $action));
         }
 
         $this->redirect($this->referer());

--- a/src/Controller/MenuItemsController.php
+++ b/src/Controller/MenuItemsController.php
@@ -52,12 +52,10 @@ class MenuItemsController extends AppController
             $menuItem = $this->MenuItems->patchEntity($menuItem, $data);
             if ($this->MenuItems->save($menuItem)) {
                 $this->Flash->success((string)__('The menu item has been saved.'));
-
                 $this->redirect(['controller' => 'Menus', 'action' => 'view', $menu->id]);
 
                 return;
             } else {
-                $this->Flash->error((string)__('The menu item could not be saved. Please, try again.'));
                 $this->Flash->error((string)__('The menu item could not be saved. Please, try again.'));
             }
         }

--- a/src/Controller/MenusController.php
+++ b/src/Controller/MenusController.php
@@ -11,7 +11,6 @@
  */
 namespace Menu\Controller;
 
-use Cake\Http\Response;
 use Cake\ORM\TableRegistry;
 use Menu\Controller\AppController;
 
@@ -83,12 +82,12 @@ class MenusController extends AppController
             $data = (array)$this->request->getData();
             $menu = $this->Menus->patchEntity($menu, $data);
             if ($this->Menus->save($menu)) {
-                $this->Flash->success(__('The menu has been saved.'));
+                $this->Flash->success((string)__('The menu has been saved.'));
                 $this->redirect(['action' => 'index']);
 
                 return;
             } else {
-                $this->Flash->error(__('The menu could not be saved. Please, try again.'));
+                $this->Flash->error((string)__('The menu could not be saved. Please, try again.'));
             }
         }
         $this->set('navMenu', $menu);
@@ -99,7 +98,7 @@ class MenusController extends AppController
      * Edit method
      *
      * @param string|null $id Menu id.
-     * @return \Cake\Http\Response|null Redirects on successful edit, renders view otherwise.
+     * @return void Redirects on successful edit, renders view otherwise.
      */
     public function edit(string $id = null): void
     {
@@ -110,12 +109,12 @@ class MenusController extends AppController
             $data = (array)$this->request->getData();
             $menu = $this->Menus->patchEntity($menu, $data);
             if ($this->Menus->save($menu)) {
-                $this->Flash->success(__('The menu has been saved.'));
+                $this->Flash->success((string)__('The menu has been saved.'));
                 $this->redirect(['action' => 'index']);
 
                 return;
             } else {
-                $this->Flash->error(__('The menu could not be saved. Please, try again.'));
+                $this->Flash->error((string)__('The menu could not be saved. Please, try again.'));
             }
         }
         $this->set('navMenu', $menu);
@@ -134,9 +133,9 @@ class MenusController extends AppController
         $this->request->allowMethod(['post', 'delete']);
         $menu = $this->Menus->get($id);
         if ($this->Menus->delete($menu)) {
-            $this->Flash->success(__('The menu has been deleted.'));
+            $this->Flash->success((string)__('The menu has been deleted.'));
         } else {
-            $this->Flash->error(__('The menu could not be deleted. Please, try again.'));
+            $this->Flash->error((string)__('The menu could not be deleted. Please, try again.'));
         }
 
         $this->redirect(['action' => 'index']);

--- a/src/Controller/MenusController.php
+++ b/src/Controller/MenusController.php
@@ -11,6 +11,8 @@
  */
 namespace Menu\Controller;
 
+use Cake\Http\Response;
+use Cake\ORM\TableRegistry;
 use Menu\Controller\AppController;
 
 /**
@@ -51,13 +53,13 @@ class MenusController extends AppController
             ]
         ]);
 
-        if ($menu->menu_items) {
-            $tree = $this->Menus->MenuItems
+        if ($menu->get('menu_items')) {
+            $tree = TableRegistry::get('MenuItems')
                 ->find('treeList', ['spacer' => self::TREE_SPACER])
                 ->where(['MenuItems.menu_id' => $menu->id])
                 ->toArray();
             // create node property in the entity object
-            foreach ($menu->menu_items as $menuItem) {
+            foreach ($menu->get('menu_items') as $menuItem) {
                 if (!array_key_exists($menuItem->id, $tree)) {
                     continue;
                 }
@@ -72,13 +74,14 @@ class MenusController extends AppController
     /**
      * Add method
      *
-     * @return \Cake\Http\Response|void Redirects on successful add, renders view otherwise.
+     * @return \Cake\Http\Response|null Redirects on successful add, renders view otherwise.
      */
-    public function add()
+    public function add(): ? Response
     {
         $menu = $this->Menus->newEntity();
         if ($this->request->is('post')) {
-            $menu = $this->Menus->patchEntity($menu, $this->request->data);
+            $data = (array)$this->request->getData();
+            $menu = $this->Menus->patchEntity($menu, $data);
             if ($this->Menus->save($menu)) {
                 $this->Flash->success(__('The menu has been saved.'));
 
@@ -95,16 +98,16 @@ class MenusController extends AppController
      * Edit method
      *
      * @param string|null $id Menu id.
-     * @return \Cake\Http\Response|void Redirects on successful edit, renders view otherwise.
-     * @throws \Cake\Http\Exception\NotFoundException When record not found.
+     * @return \Cake\Http\Response|null Redirects on successful edit, renders view otherwise.
      */
-    public function edit(string $id = null)
+    public function edit(string $id = null): ?Response
     {
         $menu = $this->Menus->get($id, [
             'contain' => []
         ]);
         if ($this->request->is(['patch', 'post', 'put'])) {
-            $menu = $this->Menus->patchEntity($menu, $this->request->data);
+            $data = (array)$this->request->getData();
+            $menu = $this->Menus->patchEntity($menu, $data);
             if ($this->Menus->save($menu)) {
                 $this->Flash->success(__('The menu has been saved.'));
 
@@ -124,7 +127,7 @@ class MenusController extends AppController
      * @return \Cake\Http\Response|null Redirects to index.
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
-    public function delete(string $id = null)
+    public function delete(string $id = null): ?Response
     {
         $this->request->allowMethod(['post', 'delete']);
         $menu = $this->Menus->get($id);

--- a/src/Controller/MenusController.php
+++ b/src/Controller/MenusController.php
@@ -54,7 +54,7 @@ class MenusController extends AppController
         ]);
 
         if ($menu->get('menu_items')) {
-            $tree = TableRegistry::get('MenuItems')
+            $tree = TableRegistry::get('Menu.MenuItems')
                 ->find('treeList', ['spacer' => self::TREE_SPACER])
                 ->where(['MenuItems.menu_id' => $menu->id])
                 ->toArray();
@@ -74,9 +74,9 @@ class MenusController extends AppController
     /**
      * Add method
      *
-     * @return \Cake\Http\Response|null Redirects on successful add, renders view otherwise.
+     * @return void Redirects on successful add, renders view otherwise.
      */
-    public function add(): ? Response
+    public function add(): void
     {
         $menu = $this->Menus->newEntity();
         if ($this->request->is('post')) {
@@ -84,8 +84,9 @@ class MenusController extends AppController
             $menu = $this->Menus->patchEntity($menu, $data);
             if ($this->Menus->save($menu)) {
                 $this->Flash->success(__('The menu has been saved.'));
+                $this->redirect(['action' => 'index']);
 
-                return $this->redirect(['action' => 'index']);
+                return;
             } else {
                 $this->Flash->error(__('The menu could not be saved. Please, try again.'));
             }
@@ -100,7 +101,7 @@ class MenusController extends AppController
      * @param string|null $id Menu id.
      * @return \Cake\Http\Response|null Redirects on successful edit, renders view otherwise.
      */
-    public function edit(string $id = null): ?Response
+    public function edit(string $id = null): void
     {
         $menu = $this->Menus->get($id, [
             'contain' => []
@@ -110,8 +111,9 @@ class MenusController extends AppController
             $menu = $this->Menus->patchEntity($menu, $data);
             if ($this->Menus->save($menu)) {
                 $this->Flash->success(__('The menu has been saved.'));
+                $this->redirect(['action' => 'index']);
 
-                return $this->redirect(['action' => 'index']);
+                return;
             } else {
                 $this->Flash->error(__('The menu could not be saved. Please, try again.'));
             }
@@ -124,10 +126,10 @@ class MenusController extends AppController
      * Delete method
      *
      * @param string|null $id Menu id.
-     * @return \Cake\Http\Response|null Redirects to index.
+     * @return void Redirects to index.
      * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
      */
-    public function delete(string $id = null): ?Response
+    public function delete(string $id = null): void
     {
         $this->request->allowMethod(['post', 'delete']);
         $menu = $this->Menus->get($id);
@@ -137,6 +139,6 @@ class MenusController extends AppController
             $this->Flash->error(__('The menu could not be deleted. Please, try again.'));
         }
 
-        return $this->redirect(['action' => 'index']);
+        $this->redirect(['action' => 'index']);
     }
 }

--- a/src/MenuBuilder/BaseMenuItem.php
+++ b/src/MenuBuilder/BaseMenuItem.php
@@ -33,37 +33,37 @@ abstract class BaseMenuItem implements MenuItemInterface
     const MENU_ITEM_INTERFACE = 'MenuItemInterface';
 
     /**
-     * @var $label
+     * @var string Text label for this menu item
      */
     protected $label = '';
 
     /**
-     * @var $icon
+     * @var string Icon class for this menu item
      */
     protected $icon = '';
 
     /**
-     * @var $target
+     * @var string Target to be used in links
      */
     protected $target = '_self';
 
     /**
-     * @var $desc
+     * @var string Long description for this menu
      */
     protected $description = '';
 
     /**
-     * @var $url
+     * @var string URL
      */
     protected $url = '#';
 
     /**
-     * @var string confirmMsg
+     * @var string Confirmation message
      */
     protected $confirmMsg = '';
 
     /**
-     * @var string extraAttribute
+     * @var string
      */
     protected $extraAttribute = '';
 
@@ -73,17 +73,17 @@ abstract class BaseMenuItem implements MenuItemInterface
     protected $order = 1;
 
     /**
-     * @var $dataType
+     * @var string
      */
     protected $dataType = '';
 
     /**
-     * @var $rawHtml
+     * @var string Raw HTML
      */
     protected $rawHtml = '';
 
     /**
-     * @var bool
+     * @var bool Indicates whether this menu item is enabled
      */
     private $enabled = true;
 
@@ -107,7 +107,7 @@ abstract class BaseMenuItem implements MenuItemInterface
      *
      * @return string the label of this menu item, or null if this menu item has no label.
      */
-    public function getLabel()
+    public function getLabel(): string
     {
         return $this->label;
     }
@@ -118,7 +118,7 @@ abstract class BaseMenuItem implements MenuItemInterface
      * @param string $label the new label, or null for no label.
      * @return void
      */
-    public function setLabel($label)
+    public function setLabel(string $label): void
     {
         $this->label = $label;
     }
@@ -128,7 +128,7 @@ abstract class BaseMenuItem implements MenuItemInterface
      *
      * @return string the icon of this menu item, or null if this menu item has no icon.
      */
-    public function getIcon()
+    public function getIcon(): string
     {
         return $this->icon;
     }
@@ -139,7 +139,7 @@ abstract class BaseMenuItem implements MenuItemInterface
      * @param string $icon the new icon, or null for no icon.
      * @return void
      */
-    public function setIcon($icon)
+    public function setIcon(string $icon): void
     {
         $this->icon = $icon;
     }
@@ -149,7 +149,7 @@ abstract class BaseMenuItem implements MenuItemInterface
      *
      * @return string the target of this menu item.
      */
-    public function getTarget()
+    public function getTarget(): string
     {
         return $this->target;
     }
@@ -160,7 +160,7 @@ abstract class BaseMenuItem implements MenuItemInterface
      * @param string $target the new target.
      * @return void
      */
-    public function setTarget($target)
+    public function setTarget(string $target): void
     {
         $this->target = $target;
     }
@@ -170,7 +170,7 @@ abstract class BaseMenuItem implements MenuItemInterface
      *
      * @return string the description of this menu item, or null if this menu item has no description.
      */
-    public function getDescription()
+    public function getDescription(): string
     {
         return $this->description;
     }
@@ -181,7 +181,7 @@ abstract class BaseMenuItem implements MenuItemInterface
      * @param string $descr the new description, or null for no description.
      * @return void
      */
-    public function setDescription($descr)
+    public function setDescription(string $descr): void
     {
         $this->description = $descr;
     }
@@ -191,7 +191,7 @@ abstract class BaseMenuItem implements MenuItemInterface
      *
      * @return string|array the URL of this menu item, or null if this menu item has no URL.
      */
-    public function getUrl()
+    public function getUrl(): string
     {
         return $this->url;
     }
@@ -202,7 +202,7 @@ abstract class BaseMenuItem implements MenuItemInterface
      * @param string|array $url the new URL, or null for no URL.
      * @return void
      */
-    public function setUrl($url)
+    public function setUrl($url): void
     {
         $this->url = $url;
     }
@@ -212,7 +212,7 @@ abstract class BaseMenuItem implements MenuItemInterface
      *
      * @return string confirmation message
      */
-    public function getConfirmMsg()
+    public function getConfirmMsg(): string
     {
         return $this->confirmMsg;
     }
@@ -223,7 +223,7 @@ abstract class BaseMenuItem implements MenuItemInterface
      * @param string $message for confirmation alert
      * @return void
      */
-    public function setConfirmMsg($message)
+    public function setConfirmMsg(string $message): void
     {
         $this->confirmMsg = $message;
     }
@@ -233,7 +233,7 @@ abstract class BaseMenuItem implements MenuItemInterface
      *
      * @return string menu item extraAttribute
      */
-    public function getExtraAttribute()
+    public function getExtraAttribute(): string
     {
         return $this->extraAttribute;
     }
@@ -243,7 +243,7 @@ abstract class BaseMenuItem implements MenuItemInterface
      *
      * @return string the raw HTML for this menu item, or null if no HTML was provided.
      */
-    public function getRawHtml()
+    public function getRawHtml(): string
     {
         return $this->rawHtml;
     }
@@ -254,7 +254,7 @@ abstract class BaseMenuItem implements MenuItemInterface
      * @param string $rawHtml the new HTML, or null for no HTML.
      * @return void
      */
-    public function setRawHtml($rawHtml)
+    public function setRawHtml(string $rawHtml): void
     {
         $this->rawHtml = $rawHtml;
     }
@@ -262,10 +262,10 @@ abstract class BaseMenuItem implements MenuItemInterface
     /**
      *  setExtraAttribute method
      *
-     * @param string $attr for menu item
+     * @param string $attr Extra attributes for the menu item
      * @return void
      */
-    public function setExtraAttribute($attr)
+    public function setExtraAttribute(string $attr)
     {
         $this->extraAttribute = $attr;
     }
@@ -275,7 +275,7 @@ abstract class BaseMenuItem implements MenuItemInterface
      *
      * @return int the position of this menu item.
      */
-    public function getOrder()
+    public function getOrder(): int
     {
         return $this->order;
     }
@@ -286,9 +286,9 @@ abstract class BaseMenuItem implements MenuItemInterface
      * @param int $order the new position.
      * @return void
      */
-    public function setOrder($order)
+    public function setOrder(int $order): void
     {
-        $this->order = (int)$order;
+        $this->order = $order;
     }
 
     /**
@@ -296,7 +296,7 @@ abstract class BaseMenuItem implements MenuItemInterface
      *
      * @return string dataType attribute
      */
-    public function getDataType()
+    public function getDataType(): string
     {
         return $this->dataType;
     }
@@ -307,7 +307,7 @@ abstract class BaseMenuItem implements MenuItemInterface
      * @param string $dataType for menu item
      * @return void
      */
-    public function setDataType($dataType)
+    public function setDataType(string $dataType): void
     {
         $this->dataType = $dataType;
     }
@@ -318,7 +318,7 @@ abstract class BaseMenuItem implements MenuItemInterface
      * @param bool $enabled Indicates whether this Menu item is enabled
      * @return void
      */
-    public function setEnabled($enabled)
+    public function setEnabled(bool $enabled): void
     {
         $this->enabled = $enabled;
     }
@@ -328,7 +328,7 @@ abstract class BaseMenuItem implements MenuItemInterface
      *
      * @return void
      */
-    public function enable()
+    public function enable(): void
     {
         $this->setEnabled(true);
     }
@@ -338,7 +338,7 @@ abstract class BaseMenuItem implements MenuItemInterface
      *
      * @return void
      */
-    public function disable()
+    public function disable(): void
     {
         $this->setEnabled(false);
     }
@@ -349,7 +349,7 @@ abstract class BaseMenuItem implements MenuItemInterface
      * @param callable $callback Callback to be evaluated as a boolean expression
      * @return void
      */
-    public function disableIf(callable $callback)
+    public function disableIf(callable $callback): void
     {
         $this->conditions[] = $callback;
     }
@@ -359,7 +359,7 @@ abstract class BaseMenuItem implements MenuItemInterface
      *
      * @return bool
      */
-    public function isEnabled()
+    public function isEnabled(): bool
     {
         // Enabled flag is set to false
         if (!$this->enabled) {
@@ -396,7 +396,7 @@ abstract class BaseMenuItem implements MenuItemInterface
      * @param string $attributeValue Attribute's value
      * @return void
      */
-    public function addAttribute($attributeName, $attributeValue)
+    public function addAttribute(string $attributeName, string $attributeValue): void
     {
         $this->attributes[$attributeName] = $attributeValue;
     }
@@ -405,9 +405,9 @@ abstract class BaseMenuItem implements MenuItemInterface
      * Returns an associative array including all the defined attributes.
      * The array's key defines the attribute name.
      *
-     * @return array
+     * @return string[]
      */
-    public function getAttributes()
+    public function getAttributes(): array
     {
         return $this->attributes;
     }
@@ -416,12 +416,12 @@ abstract class BaseMenuItem implements MenuItemInterface
      * @inheritdoc
      *
      * @param string $name Name of template file
-     * @param array $data Array of data to be made available to the rendered view (i.e. the Element)
-     * @param array $options Array of options.
+     * @param mixed[] $data Array of data to be made available to the rendered view (i.e. the Element)
+     * @param mixed[] $options Array of options.
      * @see View::element()
      * @return void
      */
-    public function setViewElement($name, array $data = [], array $options = [])
+    public function setViewElement(string $name, array $data = [], array $options = []): void
     {
         $this->viewElement = [$name, $data, $options];
     }
@@ -432,7 +432,7 @@ abstract class BaseMenuItem implements MenuItemInterface
      * @param View $view View instance that will be used for rendering
      * @return null|string
      */
-    public function renderViewElement(View $view)
+    public function renderViewElement(View $view): ?string
     {
         if (empty($this->viewElement)) {
             return null;

--- a/src/MenuBuilder/BaseMenuItem.php
+++ b/src/MenuBuilder/BaseMenuItem.php
@@ -393,10 +393,10 @@ abstract class BaseMenuItem implements MenuItemInterface
      * @inheritdoc
      *
      * @param string $attributeName Attribute's name
-     * @param string $attributeValue Attribute's value
+     * @param array|string $attributeValue Attribute's value
      * @return void
      */
-    public function addAttribute(string $attributeName, string $attributeValue): void
+    public function addAttribute(string $attributeName, $attributeValue): void
     {
         $this->attributes[$attributeName] = $attributeValue;
     }

--- a/src/MenuBuilder/BaseMenuItem.php
+++ b/src/MenuBuilder/BaseMenuItem.php
@@ -53,7 +53,7 @@ abstract class BaseMenuItem implements MenuItemInterface
     protected $description = '';
 
     /**
-     * @var string URL
+     * @var array|string URL
      */
     protected $url = '#';
 
@@ -191,7 +191,7 @@ abstract class BaseMenuItem implements MenuItemInterface
      *
      * @return string|array the URL of this menu item, or null if this menu item has no URL.
      */
-    public function getUrl(): string
+    public function getUrl()
     {
         return $this->url;
     }
@@ -265,7 +265,7 @@ abstract class BaseMenuItem implements MenuItemInterface
      * @param string $attr Extra attributes for the menu item
      * @return void
      */
-    public function setExtraAttribute(string $attr)
+    public function setExtraAttribute(string $attr): void
     {
         $this->extraAttribute = $attr;
     }

--- a/src/MenuBuilder/BaseMenuRenderClass.php
+++ b/src/MenuBuilder/BaseMenuRenderClass.php
@@ -12,6 +12,7 @@
 namespace Menu\MenuBuilder;
 
 use Cake\View\View;
+use \BadMethodCallException;
 use \ReflectionClass;
 use \ReflectionException;
 
@@ -26,22 +27,22 @@ class BaseMenuRenderClass implements MenuRenderInterface
     const DEFAULT_RENDER_METHOD = 'buildLink';
 
     /**
-     * @var $format array with formats
+     * @var array $format array with formats
      */
     protected $format = [];
 
     /**
-     * @var Menu $menu
+     * @var \Menu\MenuBuilder\Menu $menu
      */
     protected $menu = null;
 
     /**
-     * @var View $viewEntity
+     * @var \Cake\View\View $viewEntity
      */
     protected $viewEntity = null;
 
     /**
-     * @var $noLabel
+     * @var bool Indicate whether we should skip displaying the labels
      */
     protected $noLabel = false;
 
@@ -61,10 +62,10 @@ class BaseMenuRenderClass implements MenuRenderInterface
     /**
      * setFormat method
      *
-     * @param array $format containing all required keys
+     * @param string[] $format containing all required keys
      * @return void
      */
-    public function setFormat(array $format = [])
+    public function setFormat(array $format = []): void
     {
         $this->format = $format;
     }
@@ -72,9 +73,9 @@ class BaseMenuRenderClass implements MenuRenderInterface
     /**
      * getFormat method
      *
-     * @return array $format containing menu settings
+     * @return string[]
      */
-    public function getFormat()
+    public function getFormat(): array
     {
         return $this->format;
     }
@@ -85,7 +86,7 @@ class BaseMenuRenderClass implements MenuRenderInterface
      * @param array $options to generate menu
      * @return string rendered menu as per specified format
      */
-    public function render(array $options = [])
+    public function render(array $options = []): string
     {
         $html = $this->format['menuStart'];
         $html .= !empty($options['title']) ? $options['title'] : '';
@@ -109,7 +110,7 @@ class BaseMenuRenderClass implements MenuRenderInterface
      * @param \Menu\MenuBuilder\MenuItemInterface $item menu item definition
      * @return string rendered menu item as HTML
      */
-    protected function renderMenuItem(MenuItemInterface $item)
+    protected function renderMenuItem(MenuItemInterface $item): string
     {
         $children = $item->getMenuItems();
 
@@ -144,7 +145,7 @@ class BaseMenuRenderClass implements MenuRenderInterface
      * @param string $extLabel additional label elements
      * @return string generated HTML element
      */
-    protected function buildItem(MenuItemInterface $item, $extLabel)
+    protected function buildItem(MenuItemInterface $item, string $extLabel = ''): string
     {
         try {
             $shortClass = (new ReflectionClass($item))->getShortName();
@@ -156,7 +157,12 @@ class BaseMenuRenderClass implements MenuRenderInterface
             $method = self::DEFAULT_RENDER_METHOD;
         }
 
-        $result = call_user_func([$this, $method], $item, $extLabel, $item->getAttributes());
+        /** @var callable $callable */
+        $callable = [$this, $method];
+        if (!is_callable($callable)) {
+            throw new BadMethodCallException(sprintf('Method %s does not exist', $method));
+        }
+        $result = call_user_func($callable, $item, $extLabel, $item->getAttributes());
         $result .= !empty($item->getRawHtml()) ? $item->getRawHtml() : '';
         $result .= $item->renderViewElement($this->viewEntity);
 
@@ -168,10 +174,10 @@ class BaseMenuRenderClass implements MenuRenderInterface
      *
      * @param MenuItemInterface $item menu item entity
      * @param string $extLabel additional label elements
-     * @param array $params HTML attributes
+     * @param string[] $params HTML attributes
      * @return string generated HTML element
      */
-    protected function buildLink(MenuItemInterface $item, $extLabel = '', $params = [])
+    protected function buildLink(MenuItemInterface $item, string $extLabel = '', array $params = []): string
     {
         $params['title'] = __($item->getLabel());
         $params['escape'] = false;
@@ -195,10 +201,10 @@ class BaseMenuRenderClass implements MenuRenderInterface
      *
      * @param MenuItemLinkButton $item menu item entity
      * @param string $extLabel additional label elements
-     * @param array $params HTML attributes
+     * @param string[] $params HTML attributes
      * @return string generated HTML element
      */
-    protected function buildLinkButton(MenuItemLinkButton $item, $extLabel, $params = [])
+    protected function buildLinkButton(MenuItemLinkButton $item, string $extLabel = '', array $params = []): string
     {
         if (empty($params['class'])) {
             $params['class'] = 'btn btn-default';
@@ -220,10 +226,10 @@ class BaseMenuRenderClass implements MenuRenderInterface
      *
      * @param MenuItemLinkModal $item menu item entity
      * @param string $extLabel additional label elements
-     * @param array $params HTML attributes
+     * @param string[] $params HTML attributes
      * @return string generated HTML element
      */
-    protected function buildLinkModal(MenuItemLinkModal $item, $extLabel, $params = [])
+    protected function buildLinkModal(MenuItemLinkModal $item, string $extLabel = '', array $params = []): string
     {
         $item->setUrl('#');
 
@@ -238,10 +244,10 @@ class BaseMenuRenderClass implements MenuRenderInterface
      *
      * @param MenuItemLinkButtonModal $item menu item entity
      * @param string $extLabel additional label elements
-     * @param array $params HTML attributes
+     * @param string[] $params HTML attributes
      * @return string generated HTML element
      */
-    protected function buildLinkButtonModal(MenuItemLinkButtonModal $item, $extLabel, $params = [])
+    protected function buildLinkButtonModal(MenuItemLinkButtonModal $item, string $extLabel = '', array $params = []): string
     {
         $item->setUrl('#');
 
@@ -257,10 +263,10 @@ class BaseMenuRenderClass implements MenuRenderInterface
      *
      * @param MenuItemPostlink $item menu item entity
      * @param string $postFix additional label elements
-     * @param array $params HTML attributes
+     * @param string[] $params HTML attributes
      * @return string generated HTML element
      */
-    protected function buildPostlink(MenuItemPostlink $item, $postFix, $params = [])
+    protected function buildPostlink(MenuItemPostlink $item, string $postFix = '', array $params = []): string
     {
         $params['title'] = $item->getLabel();
         $params['escape'] = false;
@@ -280,10 +286,10 @@ class BaseMenuRenderClass implements MenuRenderInterface
      *
      * @param MenuItemPostlinkButton $item menu item entity
      * @param string $postFix additional label elements
-     * @param array $params HTML attributes
+     * @param string[] $params HTML attributes
      * @return string generated HTML element
      */
-    protected function buildPostlinkButton(MenuItemPostlinkButton $item, $postFix, $params = [])
+    protected function buildPostlinkButton(MenuItemPostlinkButton $item, string $postFix = '', array $params = []): string
     {
         if (empty($params['class'])) {
             $params['class'] = 'btn btn-default';
@@ -297,10 +303,10 @@ class BaseMenuRenderClass implements MenuRenderInterface
      *
      * @param MenuItemButton $item menu item entity
      * @param string $postFix additional label elements
-     * @param array $params Parameters
+     * @param string[] $params Parameters
      * @return string generated HTML element
      */
-    protected function buildButton(MenuItemButton $item, $postFix, $params = [])
+    protected function buildButton(MenuItemButton $item, string $postFix = '', array $params = []): string
     {
         $params['type'] = 'button';
 
@@ -337,7 +343,7 @@ class BaseMenuRenderClass implements MenuRenderInterface
      * @param string $postFix additional label elements
      * @return string generated HTML element
      */
-    protected function buildSeparator(MenuItemSeparator $item, $postFix)
+    protected function buildSeparator(MenuItemSeparator $item, string $postFix = ''): string
     {
         $result = '<hr class="separator" />';
 

--- a/src/MenuBuilder/MenuButtonsRender.php
+++ b/src/MenuBuilder/MenuButtonsRender.php
@@ -43,6 +43,5 @@ class MenuButtonsRender extends BaseMenuRenderClass
             'itemWithChildrenEnd' => '</div>',
             'itemLabelPostfix' => '<span class="caret"></span>',
         ];
-        $this->class = 'btn btn-default';
     }
 }

--- a/src/MenuBuilder/MenuFactory.php
+++ b/src/MenuBuilder/MenuFactory.php
@@ -14,6 +14,7 @@ namespace Menu\MenuBuilder;
 
 use Cake\Core\Configure;
 use Cake\Datasource\EntityInterface;
+use Cake\Datasource\Exception\RecordNotFoundException;
 use Cake\Event\Event;
 use Cake\Event\EventDispatcherTrait;
 use Cake\ORM\TableRegistry;
@@ -179,7 +180,7 @@ class MenuFactory
             $menuInstance = $menuEntity->get('default') ?
                 $this->getMenuItemsFromEvent($name, [], $context) :
                 $this->getMenuItemsFromTable($menuEntity);
-        } catch (Exception $e) {
+        } catch (RecordNotFoundException $e) {
             $menuInstance = static::getMenuItemsFromEvent($name, [], $context);
         }
 

--- a/src/MenuBuilder/MenuFactory.php
+++ b/src/MenuBuilder/MenuFactory.php
@@ -24,6 +24,7 @@ use Menu\Event\EventName;
 use Menu\MenuBuilder\Menu;
 use Menu\MenuBuilder\MenuInterface;
 use Menu\MenuBuilder\MenuItemFactory;
+use RuntimeException;
 
 /**
  * Class MenuFactory
@@ -164,7 +165,16 @@ class MenuFactory
         // get menu
         $menuEntity = null;
         try {
-            $menuEntity = $this->Menus->findByName($name)->firstOrFail();
+            $menuEntity = $this->Menus
+                ->find('all')
+                ->where(['name' => $name])
+                ->firstOrFail();
+            if (!($menuEntity instanceof EntityInterface)) {
+                throw new RuntimeException(sprintf(
+                    'Expected value of type "Cake\Datasource\EntityInterface", got "%s" instead',
+                    gettype($menuEntity)
+                ));
+            }
 
             $menuInstance = $menuEntity->get('default') ?
                 $this->getMenuItemsFromEvent($name, [], $context) :

--- a/src/MenuBuilder/MenuFactory.php
+++ b/src/MenuBuilder/MenuFactory.php
@@ -16,7 +16,6 @@ use Cake\Core\Configure;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
 use Cake\Event\EventDispatcherTrait;
-use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\View\View;
 use Exception;

--- a/src/MenuBuilder/MenuItemContainerInterface.php
+++ b/src/MenuBuilder/MenuItemContainerInterface.php
@@ -32,7 +32,7 @@ interface MenuItemContainerInterface
     /**
      *  Returns the menu items.
      *
-     * @return array List of menu items
+     * @return \Menu\MenuBuilder\MenuItemInterface[] List of menu items
      */
     public function getMenuItems(): array;
 

--- a/src/MenuBuilder/MenuItemContainerInterface.php
+++ b/src/MenuBuilder/MenuItemContainerInterface.php
@@ -27,14 +27,14 @@ interface MenuItemContainerInterface
      * @param MenuItemInterface $item the menu item to be added
      * @return void
      */
-    public function addMenuItem(MenuItemInterface $item);
+    public function addMenuItem(MenuItemInterface $item): void;
 
     /**
      *  Returns the menu items.
      *
      * @return array List of menu items
      */
-    public function getMenuItems();
+    public function getMenuItems(): array;
 
     /**
      * Removes the specified menu item from this container.
@@ -43,5 +43,5 @@ interface MenuItemContainerInterface
      * @param MenuItemInterface $item  The item to be removed from the menu.
      * @return void
      */
-    public function removeMenuItem(MenuItemInterface $item);
+    public function removeMenuItem(MenuItemInterface $item): void;
 }

--- a/src/MenuBuilder/MenuItemContainerTrait.php
+++ b/src/MenuBuilder/MenuItemContainerTrait.php
@@ -26,7 +26,7 @@ trait MenuItemContainerTrait
      * @param MenuItemInterface $item the menu item to be added
      * @return void
      */
-    public function addMenuItem(MenuItemInterface $item)
+    public function addMenuItem(MenuItemInterface $item): void
     {
         array_push($this->menuItems, $item);
     }
@@ -36,7 +36,7 @@ trait MenuItemContainerTrait
      *
      * @return array List of menu items
      */
-    public function getMenuItems()
+    public function getMenuItems(): array
     {
         usort($this->menuItems, function ($a, $b) {
             return $a->getOrder() > $b->getOrder();
@@ -52,7 +52,7 @@ trait MenuItemContainerTrait
      * @param MenuItemInterface $item  The item to be removed from the menu.
      * @return void
      */
-    public function removeMenuItem(MenuItemInterface $item)
+    public function removeMenuItem(MenuItemInterface $item): void
     {
         $key = array_search($item, $this->menuItems, true);
         if ($key !== false) {

--- a/src/MenuBuilder/MenuItemFactory.php
+++ b/src/MenuBuilder/MenuItemFactory.php
@@ -12,6 +12,7 @@
 namespace Menu\MenuBuilder;
 
 use Cake\Utility\Inflector;
+use InvalidArgumentException;
 use Menu\MenuBuilder\BaseMenuItem;
 
 /**
@@ -27,7 +28,7 @@ final class MenuItemFactory
      * @param array $item menu item definition
      * @return \Menu\MenuBuilder\MenuItemInterface object
      */
-    public static function createMenuItem($item)
+    public static function createMenuItem($item): MenuItemInterface
     {
         $menuItem = static::_getMenuItemObject($item);
         foreach ($item as $key => $value) {
@@ -57,9 +58,10 @@ final class MenuItemFactory
      * _getMenuItemObject method
      *
      * @param array $data menu definition
-     * @return \Menu\MenuBuilder\MenuItemInterface object or throw exception
+     * @return \Menu\MenuBuilder\MenuItemInterface object
+     * @throws InvalidArgumentException
      */
-    protected static function _getMenuItemObject($data)
+    protected static function _getMenuItemObject($data): MenuItemInterface
     {
         $itemType = !empty($data['type']) ? $data['type'] : BaseMenuItem::DEFAULT_MENU_ITEM_TYPE;
 
@@ -70,6 +72,6 @@ final class MenuItemFactory
             return new $className();
         }
 
-        throw new \InvalidArgumentException("Unknown menu item type [$itemType]!");
+        throw new InvalidArgumentException("Unknown menu item type [$itemType]!");
     }
 }

--- a/src/MenuBuilder/MenuItemFactory.php
+++ b/src/MenuBuilder/MenuItemFactory.php
@@ -25,10 +25,10 @@ final class MenuItemFactory
     /**
      *  createMenuItem method
      *
-     * @param array $item menu item definition
+     * @param mixed[] $item menu item definition
      * @return \Menu\MenuBuilder\MenuItemInterface object
      */
-    public static function createMenuItem($item): MenuItemInterface
+    public static function createMenuItem(array $item): MenuItemInterface
     {
         $menuItem = static::_getMenuItemObject($item);
         foreach ($item as $key => $value) {
@@ -57,11 +57,11 @@ final class MenuItemFactory
     /**
      * _getMenuItemObject method
      *
-     * @param array $data menu definition
+     * @param mixed[] $data menu definition
      * @return \Menu\MenuBuilder\MenuItemInterface object
      * @throws InvalidArgumentException
      */
-    protected static function _getMenuItemObject($data): MenuItemInterface
+    protected static function _getMenuItemObject(array $data): MenuItemInterface
     {
         $itemType = !empty($data['type']) ? $data['type'] : BaseMenuItem::DEFAULT_MENU_ITEM_TYPE;
 

--- a/src/MenuBuilder/MenuItemInterface.php
+++ b/src/MenuBuilder/MenuItemInterface.php
@@ -201,10 +201,10 @@ interface MenuItemInterface extends MenuItemContainerInterface
      * If the attribute already exists it will be overwritten.
      *
      * @param string $attributeName Attribute's name
-     * @param string $attributeValue Attribute's value
+     * @param string|array $attributeValue Attribute's value
      * @return void
      */
-    public function addAttribute(string $attributeName, string $attributeValue): void;
+    public function addAttribute(string $attributeName, $attributeValue): void;
 
     /**
      * Returns an associative array including all the defined attributes.

--- a/src/MenuBuilder/MenuItemInterface.php
+++ b/src/MenuBuilder/MenuItemInterface.php
@@ -26,7 +26,7 @@ interface MenuItemInterface extends MenuItemContainerInterface
      * @param bool $enabled Indicates whether this Menu item is enabled
      * @return void
      */
-    public function setEnabled($enabled);
+    public function setEnabled(bool $enabled): void;
 
     /**
      * Sets the enabled flag to true.
@@ -34,7 +34,7 @@ interface MenuItemInterface extends MenuItemContainerInterface
      * @see MenuItemInterface::setEnabled()
      * @return void
      */
-    public function enable();
+    public function enable(): void;
 
     /**
      * Sets the enabled flag to false.
@@ -42,14 +42,14 @@ interface MenuItemInterface extends MenuItemContainerInterface
      * @see MenuItemInterface::setEnabled()
      * @return  void
      */
-    public function disable();
+    public function disable(): void;
 
     /**
      * Adds a new condition to determine whether this item must be disabled
      * @param callable $callback Callback to be evaluated as a boolean expression
      * @return void
      */
-    public function disableIf(callable $callback);
+    public function disableIf(callable $callback): void;
 
     /**
      * Returns true only and only if:
@@ -58,14 +58,14 @@ interface MenuItemInterface extends MenuItemContainerInterface
      * - if having child menu items, one of them is enabled
      * @return bool
      */
-    public function isEnabled();
+    public function isEnabled(): bool;
 
     /**
      * Gets the text label for this menu item.
      *
      * @return string the label of this menu item, or null if this menu item has no label.
      */
-    public function getLabel();
+    public function getLabel(): string;
 
     /**
      * Sets the text label for this menu item to the specified label.
@@ -73,14 +73,14 @@ interface MenuItemInterface extends MenuItemContainerInterface
      * @param string $label the new label, or null for no label.
      * @return void
      */
-    public function setLabel($label);
+    public function setLabel(string $label): void;
 
     /**
      * Gets the icon for this menu item.
      *
      * @return string the icon of this menu item, or null if this menu item has no icon.
      */
-    public function getIcon();
+    public function getIcon(): string;
 
     /**
      * Sets the icon for this menu item to the specified icon.
@@ -89,14 +89,14 @@ interface MenuItemInterface extends MenuItemContainerInterface
      * @param string $icon the new icon, or null for no icon.
      * @return void
      */
-    public function setIcon($icon);
+    public function setIcon(string $icon): void;
 
     /**
      * Gets the text description for this menu item.
      *
      * @return string the description of this menu item, or null if this menu item has no description.
      */
-    public function getDescription();
+    public function getDescription(): string;
 
     /**
      * Sets the text description for this menu item to the specified description.
@@ -104,7 +104,7 @@ interface MenuItemInterface extends MenuItemContainerInterface
      * @param string $descr the new description, or null for no description.
      * @return void
      */
-    public function setDescription($descr);
+    public function setDescription(string $descr): void;
 
     /**
      * Gets the URL for this menu item.
@@ -119,7 +119,7 @@ interface MenuItemInterface extends MenuItemContainerInterface
      * @param string|array $url the new URL, or null for no URL.
      * @return void
      */
-    public function setUrl($url);
+    public function setUrl($url): void;
 
     /**
      * Gets the order position for this menu item.
@@ -127,7 +127,7 @@ interface MenuItemInterface extends MenuItemContainerInterface
      *
      * @return int the position of this menu item.
      */
-    public function getOrder();
+    public function getOrder(): int;
 
     /**
      * Sets the order position for this menu item to the specified order.
@@ -135,7 +135,7 @@ interface MenuItemInterface extends MenuItemContainerInterface
      * @param int $order the new position.
      * @return void
      */
-    public function setOrder($order);
+    public function setOrder(int $order): void;
 
     /**
      * Gets the target for this menu item.
@@ -143,7 +143,7 @@ interface MenuItemInterface extends MenuItemContainerInterface
      *
      * @return string the target of this menu item.
      */
-    public function getTarget();
+    public function getTarget(): string;
 
     /**
      * Sets target for this menu item to the specified target.
@@ -158,14 +158,14 @@ interface MenuItemInterface extends MenuItemContainerInterface
      * @param string $target the new target.
      * @return void
      */
-    public function setTarget($target);
+    public function setTarget(string $target): void;
 
     /**
      * Returns the raw HTML for this menu item.
      *
      * @return string the raw HTML for this menu item, or null if no HTML was provided.
      */
-    public function getRawHtml();
+    public function getRawHtml(): string;
 
     /**
      * Sets the raw HTML for this menu item to the specified HTML.
@@ -173,19 +173,19 @@ interface MenuItemInterface extends MenuItemContainerInterface
      * @param string $rawHtml the new HTML, or null for no HTML.
      * @return void
      */
-    public function setRawHtml($rawHtml);
+    public function setRawHtml(string $rawHtml): void;
 
     /**
      * Assigns a view element to be rendered and appended to the auto generated menu item.
      * This can be used to extend default behaviour like invoke modals or vue applications
      *
      * @param string $name Name of template file
-     * @param array $data Array of data to be made available to the rendered view (i.e. the Element)
-     * @param array $options Array of options.
+     * @param mixed[] $data Array of data to be made available to the rendered view (i.e. the Element)
+     * @param mixed[] $options Array of options.
      * @see View::element()
      * @return void
      */
-    public function setViewElement($name, array $data = [], array $options = []);
+    public function setViewElement(string $name, array $data = [], array $options = []): void;
 
     /**
      * Renders the view element provided by setViewElement by using the provided view instance.
@@ -194,7 +194,7 @@ interface MenuItemInterface extends MenuItemContainerInterface
      * @param View $view View instance that will be used for rendering
      * @return null|string
      */
-    public function renderViewElement(View $view);
+    public function renderViewElement(View $view): ?string;
 
     /**
      * Adds an HTML attribute for this menu item.
@@ -204,13 +204,13 @@ interface MenuItemInterface extends MenuItemContainerInterface
      * @param string $attributeValue Attribute's value
      * @return void
      */
-    public function addAttribute($attributeName, $attributeValue);
+    public function addAttribute(string $attributeName, string $attributeValue): void;
 
     /**
      * Returns an associative array including all the defined attributes.
      * The array's key defines the attribute name.
      *
-     * @return array
+     * @return string[]
      */
-    public function getAttributes();
+    public function getAttributes(): array;
 }

--- a/src/MenuBuilder/MenuRenderInterface.php
+++ b/src/MenuBuilder/MenuRenderInterface.php
@@ -21,8 +21,8 @@ interface MenuRenderInterface
     /**
      *  render method
      *
-     * @param array $options to generate menu
+     * @param mixed[] $options to generate menu
      * @return string rendered menu as per specified format
      */
-    public function render(array $options = []);
+    public function render(array $options = []): string;
 }

--- a/src/Model/Table/MenuItemsTable.php
+++ b/src/Model/Table/MenuItemsTable.php
@@ -114,18 +114,20 @@ class MenuItemsTable extends Table
     }
 
     /**
-     * {@inheritDoc}
+     * Fallback to default values for icon and url
+     *
+     * @return void
      */
-    public function beforeSave(Event $event, EntityInterface $entity, ArrayObject $options)
+    public function beforeSave(Event $event, EntityInterface $entity, ArrayObject $options): void
     {
         // fallback to default icon
-        if (!$entity->icon) {
-            $entity->icon = Configure::read('Icons.default');
+        if (!$entity->get('icon')) {
+            $entity->set('icon', Configure::read('Icons.default'));
         }
 
         // fallback to hashtag as default url
-        if (!$entity->url) {
-            $entity->url = '#';
+        if (!$entity->get('url')) {
+            $entity->set('url', '#');
         }
     }
 }

--- a/src/Shell/MenuShell.php
+++ b/src/Shell/MenuShell.php
@@ -33,7 +33,7 @@ class MenuShell extends Shell
         $parser = parent::getOptionParser();
 
         $parser
-            ->description('Menu Shell that handle\'s related tasks.')
+            ->setDescription('Menu Shell that handle\'s related tasks.')
             ->addSubcommand(
                 'import',
                 ['help' => 'Import system menus.', 'parser' => $this->Import->getOptionParser()]

--- a/src/Shell/Task/ImportTask.php
+++ b/src/Shell/Task/ImportTask.php
@@ -12,9 +12,7 @@
 namespace Menu\Shell\Task;
 
 use Cake\Console\Shell;
-use Cake\Core\Configure;
-use Cake\ORM\Entity;
-use Cake\ORM\Table;
+use Cake\Datasource\EntityInterface;
 use Cake\ORM\TableRegistry;
 
 /**
@@ -59,7 +57,7 @@ class ImportTask extends Shell
             $entity = $table->patchEntity($entity, $menu);
             $result = $table->save($entity);
             if (!$result) {
-                $this->err("Errors: \n", implode("\n", $this->getImportErrors($entity)));
+                $this->err("Errors: \n" . implode("\n", $this->getImportErrors($entity)));
                 $this->abort("Failed to create menu [" . $menu['name'] . "]");
             }
         }
@@ -97,18 +95,18 @@ class ImportTask extends Shell
     /**
      * Get import errors from entity object.
      *
-     * @param  \Cake\ORM\Entity $entity Entity instance
-     * @return array
+     * @param \Cake\Datasource\EntityInterface $entity Entity instance
+     * @return string[]
      */
-    protected function getImportErrors(Entity $entity)
+    protected function getImportErrors(EntityInterface $entity): array
     {
         $result = [];
 
-        if (empty($entity->errors())) {
+        if (empty($entity->getErrors())) {
             return $result;
         }
 
-        foreach ($entity->errors() as $field => $error) {
+        foreach ($entity->getErrors() as $field => $error) {
             $msg = "[$field] ";
             $msg .= is_array($error) ? implode(', ', $error) : $error;
             $result[] = $msg;

--- a/tests/TestCase/MenuBuilder/MenuItemButtonTest.php
+++ b/tests/TestCase/MenuBuilder/MenuItemButtonTest.php
@@ -79,7 +79,7 @@ class MenuItemButtonTest extends TestCase
     public function providerConfirmMsg(): array
     {
         return [
-            [null, ''],
+            ['', ''],
             ["It's a trap!", "It's a trap!"],
         ];
     }
@@ -143,7 +143,6 @@ class MenuItemButtonTest extends TestCase
     {
         return [
             ['foo', 'foo', "Didn't work with strings"],
-            [['hey' => 'jude'], ['hey' => 'jude'], "Can't use arrays"],
         ];
     }
 
@@ -165,8 +164,6 @@ class MenuItemButtonTest extends TestCase
     public function providerButtonOrder(): array
     {
         return [
-            ['', 0, "Wrong casting"],
-            ['abc', 0, "Wrong casting"],
             [1, 1, "Cannot get integers running"],
         ];
     }
@@ -275,8 +272,8 @@ class MenuItemButtonTest extends TestCase
     public function testAttributes(): void
     {
         $item = new MenuItemButton();
-        $item->addAttribute('one', 1);
+        $item->addAttribute('one', '1');
         $attrs = $item->getAttributes();
-        $this->assertEquals(1, $attrs['one']);
+        $this->assertEquals('1', $attrs['one']);
     }
 }


### PR DESCRIPTION
Resolves the reported errors by phpstan. There are only three errors pending:

* Two of the errors are related to defined constants in `config/bootstrap.php` that are being reported as `undefined`. Most probably we will need to adjust phpstan configuration or move definitions in another file.
* One complaint about undefined property in Menu ViewHelper.