### PR TITLE
Adding MenuItemGroup and wrapper properties to MenuItem (task #7362)

### DIFF
--- a/src/MenuBuilder/BaseMenuItem.php
+++ b/src/MenuBuilder/BaseMenuItem.php
@@ -102,6 +102,10 @@ abstract class BaseMenuItem implements MenuItemInterface
      */
     protected $viewElement = [];
 
+    protected $wrapperStart = '';
+
+    protected $wrapperEnd = '';
+
     /**
      * @inheritdoc
      *
@@ -439,5 +443,47 @@ abstract class BaseMenuItem implements MenuItemInterface
         }
 
         return call_user_func_array([$view, 'element'], $this->viewElement);
+    }
+
+    /**
+     * Set Wrapper for MenuItem
+     *
+     * @string $value
+     * @return void
+     */
+    public function setWrapperStart(string $value)
+    {
+        $this->wrapperStart = $value;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @return string
+     */
+    public function getWrapperEnd(): string
+    {
+        return $this->wrapperEnd;
+    }
+
+    /**
+     * Set Wrapper Start for MenuItem
+     *
+     * @string $value
+     * @return void
+     */
+    public function setWrapperStart(string $value)
+    {
+        $this->wrapperStart = $value;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @return string
+     */
+    public function getWrapperStart(): string
+    {
+        return $this->wrapperStart;
     }
 }

--- a/src/MenuBuilder/BaseMenuItem.php
+++ b/src/MenuBuilder/BaseMenuItem.php
@@ -448,12 +448,12 @@ abstract class BaseMenuItem implements MenuItemInterface
     /**
      * Set Wrapper for MenuItem
      *
-     * @string $value
+     * @param string $value of wrapper end
      * @return void
      */
-    public function setWrapperStart(string $value)
+    public function setWrapperEnd(string $value): void
     {
-        $this->wrapperStart = $value;
+        $this->wrapperEnd = $value;
     }
 
     /**
@@ -469,10 +469,10 @@ abstract class BaseMenuItem implements MenuItemInterface
     /**
      * Set Wrapper Start for MenuItem
      *
-     * @string $value
+     * @string $value of wrapper start
      * @return void
      */
-    public function setWrapperStart(string $value)
+    public function setWrapperStart(string $value): void
     {
         $this->wrapperStart = $value;
     }

--- a/src/MenuBuilder/BaseMenuItem.php
+++ b/src/MenuBuilder/BaseMenuItem.php
@@ -102,8 +102,14 @@ abstract class BaseMenuItem implements MenuItemInterface
      */
     protected $viewElement = [];
 
+    /**
+     * @var string HTML wrapper start element
+     */
     protected $wrapperStart = '';
 
+    /**
+     * @var string HTML wrapper end element
+     */
     protected $wrapperEnd = '';
 
     /**
@@ -469,7 +475,7 @@ abstract class BaseMenuItem implements MenuItemInterface
     /**
      * Set Wrapper Start for MenuItem
      *
-     * @string $value of wrapper start
+     * @param string $value of wrapper start
      * @return void
      */
     public function setWrapperStart(string $value): void

--- a/src/MenuBuilder/BaseMenuRenderClass.php
+++ b/src/MenuBuilder/BaseMenuRenderClass.php
@@ -343,10 +343,10 @@ class BaseMenuRenderClass implements MenuRenderInterface
     /**
      * @param MenuItemButtonGroup $item menu item entity
      * @param string $postFix additional label elements
-     * @param array $params Parameters
+     * @param string[] $params Parameters
      * @return string generated HTML element
      */
-    protected function buildButtonGroup(MenuItemButtonGroup $item, $postFix, $params = [])
+    protected function buildButtonGroup(MenuItemButtonGroup $item, string $postFix = '', array $params = []): string
     {
         $params['type'] = 'button';
 

--- a/src/MenuBuilder/BaseMenuRenderClass.php
+++ b/src/MenuBuilder/BaseMenuRenderClass.php
@@ -116,8 +116,7 @@ class BaseMenuRenderClass implements MenuRenderInterface
 
         $html = $this->format['itemStart'];
 
-        $html .= !empty($item->getWrapperStart()) ? $item->getWrapperStart() : '';
-
+        $html .= $item->getWrapperStart();
         $html .= $this->buildItem($item, !empty($children) && !empty($this->format['itemWithChildrenPostfix']) ? $this->format['itemWithChildrenPostfix'] : '');
 
         if (!empty($children)) {
@@ -135,8 +134,7 @@ class BaseMenuRenderClass implements MenuRenderInterface
             $html .= $this->format['childMenuEnd'];
         }
 
-        $html .= !empty($item->getWrapperEnd()) ? $item->getWrapperEnd() : '';
-
+        $html .= $item->getWrapperEnd();
         $html .= $this->format['itemEnd'];
 
         return $html;

--- a/src/MenuBuilder/BaseMenuRenderClass.php
+++ b/src/MenuBuilder/BaseMenuRenderClass.php
@@ -116,6 +116,8 @@ class BaseMenuRenderClass implements MenuRenderInterface
 
         $html = $this->format['itemStart'];
 
+        $html .= !empty($item->getWrapperStart()) ? $item->getWrapperStart() : '';
+
         $html .= $this->buildItem($item, !empty($children) && !empty($this->format['itemWithChildrenPostfix']) ? $this->format['itemWithChildrenPostfix'] : '');
 
         if (!empty($children)) {
@@ -132,6 +134,8 @@ class BaseMenuRenderClass implements MenuRenderInterface
             }
             $html .= $this->format['childMenuEnd'];
         }
+
+        $html .= !empty($item->getWrapperEnd()) ? $item->getWrapperEnd() : '';
 
         $html .= $this->format['itemEnd'];
 
@@ -307,6 +311,42 @@ class BaseMenuRenderClass implements MenuRenderInterface
      * @return string generated HTML element
      */
     protected function buildButton(MenuItemButton $item, string $postFix = '', array $params = []): string
+    {
+        $params['type'] = 'button';
+
+        if (empty($params['class'])) {
+            $params['class'] = 'btn btn-default';
+        }
+
+        if (!empty($item->getExtraAttribute())) {
+            $params['class'] = $item->getExtraAttribute();
+        }
+
+        if (!empty($item->getMenuItems())) {
+            $params['data-toggle'] = 'dropdown';
+            $params['aria-haspopup'] = 'true';
+            $params['aria-expanded'] = 'false';
+        }
+
+        $label = $item->getLabel();
+        if (!empty($item->getIcon())) {
+            $label = '<i class="fa fa-' . $item->getIcon() . '"></i> ' . $label;
+        }
+
+        if (!empty($this->format['itemLabelPostfix'])) {
+            $label .= ' ' . $this->format['itemLabelPostfix'];
+        }
+
+        return $this->viewEntity->Html->tag('button', $label, $params);
+    }
+
+    /**
+     * @param MenuItemButtonGroup $item menu item entity
+     * @param string $postFix additional label elements
+     * @param array $params Parameters
+     * @return string generated HTML element
+     */
+    protected function buildButtonGroup(MenuItemButtonGroup $item, $postFix, $params = [])
     {
         $params['type'] = 'button';
 

--- a/src/MenuBuilder/MenuItemButtonGroup.php
+++ b/src/MenuBuilder/MenuItemButtonGroup.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Menu\MenuBuilder;
+
+class MenuItemButtonGroup extends BaseMenuItem
+{
+    protected $wrapperStart = '<div class="btn-group btn-group-sm">';
+
+    protected $wrapperEnd = '</div>';
+}

--- a/src/MenuBuilder/MenuItemInterface.php
+++ b/src/MenuBuilder/MenuItemInterface.php
@@ -213,4 +213,39 @@ interface MenuItemInterface extends MenuItemContainerInterface
      * @return string[]
      */
     public function getAttributes(): array;
+
+    /**
+     * Set Wrapper Start for MenuItem class
+     *
+     * Allows wrapping Html string within HTML div-like containers.
+     * Pretty useful for UI elements like button groups.
+     *
+     * @param string $value of the wrapper
+     * @return void
+     */
+    public function setWrapperStart(string $value): void;
+
+    /**
+     * Set Wrapper End for MenuItem class
+     *
+     * Allows wrapping Html string of MenuItem with div-like containers.
+     *
+     * @param string $value closing of the wrapper
+     * @return void
+     */
+    public function setWrapperEnd(string $value): void;
+
+    /**
+     * Return Wrapper start of MenuItem
+     *
+     * @return string
+     */
+    public function getWrapperStart(): string;
+
+    /**
+     * Return Wrapper end of MenuItem
+     *
+     * @return string
+     */
+    public function getWrapperEnd(): string;
 }


### PR DESCRIPTION
Using dropdown menu items within `.btn-group` required extra wrappers around the element.

In order for the dropdown menu to expand its `.dropdown-menu` ul-container, we need to surround it with `.btn-group` container.

Example:
```html
<div class="btn-group btn-group-sm"> <!-- global menu container -->
  <button class="btn btn-default">Foo</button>
  <div class="btn-group btn-group-sm"> <!-- $wrapperStart -->
     <button class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Dropdown Button</button>
     <ul class="dropdown-menu">
           <li><a href="#">Option 1</a></li>
     </ul>
   </div> <!-- $wrapperEnd -->
</div>
```

Without `wrapperStart/wrapperEnd` properties, `.open` class will be assigned to `global menu container` which will lead into opening first occurance of `.dropdown-menu` within the container.

[Bootstrap Reference v3.7](https://getbootstrap.com/docs/3.3/components/#btn-dropdowns-split)
