### PR TITLE
Fixing menus after AdminLTE upgrade (#task #9313)

### DIFF
--- a/src/MenuBuilder/BaseMenuRenderClass.php
+++ b/src/MenuBuilder/BaseMenuRenderClass.php
@@ -114,7 +114,11 @@ class BaseMenuRenderClass implements MenuRenderInterface
     {
         $children = $item->getMenuItems();
 
-        $html = $this->format['itemStart'];
+        if (!empty($children) && !empty($this->format['itemStartWithChildren'])) {
+            $html = $this->format['itemStartWithChildren'];
+        } else {
+            $html = $this->format['itemStart'];
+        }
 
         $html .= $item->getWrapperStart();
         $html .= $this->buildItem($item, !empty($children) && !empty($this->format['itemWithChildrenPostfix']) ? $this->format['itemWithChildrenPostfix'] : '');
@@ -135,7 +139,12 @@ class BaseMenuRenderClass implements MenuRenderInterface
         }
 
         $html .= $item->getWrapperEnd();
-        $html .= $this->format['itemEnd'];
+
+        if (!empty($children) && !empty($this->format['itemEndWithChildren'])) {
+            $html .= $this->format['itemEndWithChildren'];
+        } else {
+            $html .= $this->format['itemEnd'];
+        }
 
         return $html;
     }

--- a/src/MenuBuilder/MainMenuRenderAdminLte.php
+++ b/src/MenuBuilder/MainMenuRenderAdminLte.php
@@ -31,12 +31,14 @@ class MainMenuRenderAdminLte extends BaseMenuRenderClass
     {
         parent::__construct($menu, $viewEntity);
         $format = [
-            'menuStart' => '<ul class="sidebar-menu">',
+            'menuStart' => '<ul class="sidebar-menu" data-widget="tree">',
             'menuEnd' => '</ul>',
             'childMenuStart' => '<ul class="treeview-menu">',
             'childMenuEnd' => '</ul>',
-            'itemStart' => '<li class="treeview">',
+            'itemStart' => '<li>',
+            'itemStartWithChildren' => '<li class="treeview">',
             'itemEnd' => '</li>',
+            'itemEndWithChildren' => '</li>',
             'itemWrapperStart' => '<span>',
             'itemWrapperEnd' => '</span>',
             //'item' => '<a href="%url%" target="%target%"><i class="fa fa-%icon%"></i> <span>%label%</span></a>',

--- a/src/Template/Element/MenuItems/post.ctp
+++ b/src/Template/Element/MenuItems/post.ctp
@@ -15,7 +15,7 @@ use Menu\Type\TypeFactory;
 echo $this->Html->css(
     [
         'AdminLTE./plugins/iCheck/all',
-        'AdminLTE./plugins/select2/select2.min',
+        'AdminLTE./bower_components/select2/dist/css/select2.min',
         'Qobo/Utils.select2-bootstrap.min',
         'Qobo/Utils.select2-style'
     ],
@@ -24,7 +24,7 @@ echo $this->Html->css(
 echo $this->Html->script(
     [
         'AdminLTE./plugins/iCheck/icheck.min',
-        'AdminLTE./plugins/select2/select2.full.min',
+        'AdminLTE./bower_components/select2/dist/js/select2.full.min',
         'Qobo/Utils.select2.init',
         'Menu.view-post'
     ],


### PR DESCRIPTION
After AdminLTE upgrade to `1.1.0` jQuery Tree plugin was refactored. Now, `.treeview` should be added only to those links, that have `children`.  