### PR TITLE
Support for CakePHP v3.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,11 +24,11 @@
 	"repositories": [
         {
             "type": "git",
-            "url": "https://github.com/QoboLtd/cakephp-file-storage.git"
+            "url": "https://github.com/QoboLtd/cakephp-utils.git"
         }
     ],
     "require": {
-        "qobo/cakephp-utils": "^13.0"
+        "qobo/cakephp-utils": "dev-cakephp-v38a"
     },
     "require-dev": {
         "qobo/cakephp-composer-dev": "^v1.0"
@@ -59,6 +59,5 @@
         "test": "Runs phpcs and phpunit without coverage",
         "test-coverage": "Runs phpcs and phpunit with coverage enabled"
     },
-    "prefer-stable": true,
-    "minimum-stability": "dev"
+    "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -21,14 +21,8 @@
         "sort-packages": true,
         "optimize-autoloader": true
     },
-	"repositories": [
-        {
-            "type": "git",
-            "url": "https://github.com/QoboLtd/cakephp-utils.git"
-        }
-    ],
     "require": {
-        "qobo/cakephp-utils": "dev-cakephp-v38a"
+        "qobo/cakephp-utils": "^13.0"
     },
     "require-dev": {
         "qobo/cakephp-composer-dev": "^v1.0"

--- a/config/Migrations/20180516101529_PrefixMenus.php
+++ b/config/Migrations/20180516101529_PrefixMenus.php
@@ -13,6 +13,7 @@ class PrefixMenus extends AbstractMigration
     public function change()
     {
         $this->table('menus')
-            ->rename('qobo_menus');
+            ->rename('qobo_menus')
+            ->update();
     }
 }

--- a/config/Migrations/20180516101542_PrefixMenuItems.php
+++ b/config/Migrations/20180516101542_PrefixMenuItems.php
@@ -13,6 +13,7 @@ class PrefixMenuItems extends AbstractMigration
     public function change()
     {
         $this->table('menu_items')
-            ->rename('qobo_menu_items');
+            ->rename('qobo_menu_items')
+            ->update();
     }
 }

--- a/src/Controller/MenuItemsController.php
+++ b/src/Controller/MenuItemsController.php
@@ -14,7 +14,6 @@ namespace Menu\Controller;
 use Cake\Core\Configure;
 use Cake\Event\Event;
 use Cake\ORM\TableRegistry;
-use Menu\Controller\AppController;
 use Qobo\Utils\Utility;
 
 /**

--- a/src/Controller/MenusController.php
+++ b/src/Controller/MenusController.php
@@ -12,7 +12,6 @@
 namespace Menu\Controller;
 
 use Cake\ORM\TableRegistry;
-use Menu\Controller\AppController;
 
 /**
  * Menus Controller

--- a/src/MenuBuilder/MenuFactory.php
+++ b/src/MenuBuilder/MenuFactory.php
@@ -22,9 +22,6 @@ use Cake\View\View;
 use Exception;
 use InvalidArgumentException;
 use Menu\Event\EventName;
-use Menu\MenuBuilder\Menu;
-use Menu\MenuBuilder\MenuInterface;
-use Menu\MenuBuilder\MenuItemFactory;
 use RuntimeException;
 
 /**

--- a/src/MenuBuilder/MenuItemFactory.php
+++ b/src/MenuBuilder/MenuItemFactory.php
@@ -13,7 +13,6 @@ namespace Menu\MenuBuilder;
 
 use Cake\Utility\Inflector;
 use InvalidArgumentException;
-use Menu\MenuBuilder\BaseMenuItem;
 
 /**
  *  MenuItemFactory class

--- a/src/Model/Table/MenuItemsTable.php
+++ b/src/Model/Table/MenuItemsTable.php
@@ -71,29 +71,28 @@ class MenuItemsTable extends Table
     {
         $validator
             ->uuid('id')
-            ->allowEmpty('id', 'create');
+            ->allowEmptyString('id', 'create');
 
         $validator
             ->requirePresence('label', 'create')
-            ->notEmpty('label');
+            ->notEmptyString('label');
 
         $validator
-            ->allowEmpty('url');
+            ->allowEmptyString('url');
 
         $validator
-            ->boolean('new_window')
-            ->allowEmpty('new_window');
+            ->boolean('new_window');
 
         $validator
             ->requirePresence('menu_id', 'create')
-            ->notEmpty('menu_id');
+            ->notEmptyString('menu_id');
 
         $validator
-            ->allowEmpty('icon');
+            ->allowEmptyString('icon');
 
         $validator
             ->requirePresence('type', 'create')
-            ->notEmpty('type');
+            ->notEmptyString('type');
 
         return $validator;
     }

--- a/src/Model/Table/MenuItemsTable.php
+++ b/src/Model/Table/MenuItemsTable.php
@@ -69,28 +69,29 @@ class MenuItemsTable extends Table
     {
         $validator
             ->uuid('id')
-            ->allowEmptyString('id', 'create');
+            ->allowEmpty('id', 'create');
 
         $validator
             ->requirePresence('label', 'create')
-            ->notEmptyString('label');
+            ->notEmpty('label');
 
         $validator
-            ->allowEmptyString('url');
+            ->allowEmpty('url');
 
         $validator
-            ->boolean('new_window');
+            ->boolean('new_window')
+            ->allowEmpty('new_window');
 
         $validator
             ->requirePresence('menu_id', 'create')
-            ->notEmptyString('menu_id');
+            ->notEmpty('menu_id');
 
         $validator
-            ->allowEmptyString('icon');
+            ->allowEmpty('icon');
 
         $validator
             ->requirePresence('type', 'create')
-            ->notEmptyString('type');
+            ->notEmpty('type');
 
         return $validator;
     }

--- a/src/Model/Table/MenuItemsTable.php
+++ b/src/Model/Table/MenuItemsTable.php
@@ -15,11 +15,9 @@ use ArrayObject;
 use Cake\Core\Configure;
 use Cake\Datasource\EntityInterface;
 use Cake\Event\Event;
-use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\Validation\Validator;
-use Menu\Model\Entity\MenuItem;
 
 /**
  * MenuItems Model

--- a/src/Model/Table/MenusTable.php
+++ b/src/Model/Table/MenusTable.php
@@ -57,20 +57,18 @@ class MenusTable extends Table
     {
         $validator
             ->uuid('id')
-            ->allowEmpty('id', 'create');
+            ->allowEmptyString('id', 'create');
 
         $validator
             ->requirePresence('name', 'create')
-            ->notEmpty('name')
+            ->notEmptyString('name')
             ->add('name', 'unique', ['rule' => 'validateUnique', 'provider' => 'table']);
 
         $validator
-            ->boolean('active')
-            ->allowEmpty('active');
+            ->boolean('active');
 
         $validator
-            ->boolean('default')
-            ->allowEmpty('default');
+            ->boolean('default');
 
         return $validator;
     }

--- a/src/Model/Table/MenusTable.php
+++ b/src/Model/Table/MenusTable.php
@@ -56,18 +56,20 @@ class MenusTable extends Table
     {
         $validator
             ->uuid('id')
-            ->allowEmptyString('id', 'create');
+            ->allowEmpty('id', 'create');
 
         $validator
             ->requirePresence('name', 'create')
-            ->notEmptyString('name')
+            ->notEmpty('name')
             ->add('name', 'unique', ['rule' => 'validateUnique', 'provider' => 'table']);
 
         $validator
-            ->boolean('active');
+            ->boolean('active')
+            ->allowEmpty('active');
 
         $validator
-            ->boolean('default');
+            ->boolean('default')
+            ->allowEmpty('default');
 
         return $validator;
     }

--- a/src/Model/Table/MenusTable.php
+++ b/src/Model/Table/MenusTable.php
@@ -11,7 +11,6 @@
  */
 namespace Menu\Model\Table;
 
-use Cake\ORM\Query;
 use Cake\ORM\RulesChecker;
 use Cake\ORM\Table;
 use Cake\Validation\Validator;

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Menu;
+
+use Cake\Core\BasePlugin;
+
+class Plugin extends BasePlugin
+{
+    protected $name = 'Menu';
+}

--- a/src/View/Helper/MenuHelper.php
+++ b/src/View/Helper/MenuHelper.php
@@ -11,11 +11,9 @@
  */
 namespace Menu\View\Helper;
 
-use Cake\Core\Configure;
 use Cake\Routing\Router;
 use Cake\Utility\Hash;
 use Cake\View\Helper;
-use Cake\View\View;
 
 class MenuHelper extends Helper
 {

--- a/tests/TestCase/MenuBuilder/MenuFactoryTest.php
+++ b/tests/TestCase/MenuBuilder/MenuFactoryTest.php
@@ -35,17 +35,17 @@ class MenuFactoryTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.menu.menus',
-        'plugin.menu.menu_items',
+        'plugin.Menu.Menus',
+        'plugin.Menu.MenuItems',
     ];
 
     public function setUp()
     {
         parent::setUp();
-        $configMenus = TableRegistry::exists('Menus') ? [] : ['className' => 'Menu\Model\Table\MenusTable'];
-        $configMenuItems = TableRegistry::exists('MenuItems') ? [] : ['className' => 'Menu\Model\Table\MenuItemsTable'];
-        $this->Menus = TableRegistry::get('Menus', $configMenus);
-        $this->MenuItems = TableRegistry::get('MenuItems', $configMenuItems);
+        $configMenus = TableRegistry::getTableLocator()->exists('Menus') ? [] : ['className' => 'Menu\Model\Table\MenusTable'];
+        $configMenuItems = TableRegistry::getTableLocator()->exists('MenuItems') ? [] : ['className' => 'Menu\Model\Table\MenuItemsTable'];
+        $this->Menus = TableRegistry::getTableLocator()->get('Menus', $configMenus);
+        $this->MenuItems = TableRegistry::getTableLocator()->get('MenuItems', $configMenuItems);
 
         $this->instance = new MenuFactory(['user1'], true);
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -85,6 +85,14 @@ Cake\Core\Configure::write('Session', [
     'defaults' => 'php',
 ]);
 
+Cake\Core\Plugin::getCollection()->add(new \Menu\Plugin([
+    'path' => ROOT . DS,
+    'routes' => true,
+]));
+if (file_exists(ROOT . '/config/bootstrap.php')) {
+    require ROOT . '/config/bootstrap.php';
+}
+
 // Ensure default test connection is defined
 if (!getenv('db_dsn')) {
     putenv('db_dsn=sqlite:///:memory:');
@@ -104,7 +112,3 @@ Cake\Datasource\ConnectionManager::setConfig('test', [
 
 // Alias AppController to the test App
 class_alias($pluginName . '\Test\App\Controller\AppController', 'App\Controller\AppController');
-// If plugin has routes.php/bootstrap.php then load them, otherwise don't.
-$loadPluginRoutes = file_exists(ROOT . DS . 'config' . DS . 'routes.php');
-$loadPluginBootstrap = file_exists(ROOT . DS . 'config' . DS . 'bootstrap.php');
-Cake\Core\Plugin::load($pluginName, ['path' => ROOT . DS, 'autoload' => true, 'routes' => $loadPluginRoutes, 'bootstrap' => $loadPluginBootstrap]);


### PR DESCRIPTION
This PR defines v3.8 as the minimum CakePHP version acceptable and fixes most of the deprecation warnings.

